### PR TITLE
Refactor `dss initialize` to make code easier to reuse

### DIFF
--- a/src/dss/config.py
+++ b/src/dss/config.py
@@ -1,0 +1,4 @@
+# Labels applied to any Kubernetes objects managed by the DSS CLI
+DSS_CLI_MANAGER_LABELS = {"app.kubernetes.io/managed-by": "dss-cli"}
+
+FIELD_MANAGER = "dss-cli"

--- a/src/dss/config.py
+++ b/src/dss/config.py
@@ -2,3 +2,6 @@
 DSS_CLI_MANAGER_LABELS = {"app.kubernetes.io/managed-by": "dss-cli"}
 
 FIELD_MANAGER = "dss-cli"
+DSS_NAMESPACE = "dss"
+MANIFEST_TEMPLATES_LOCATION = "./manifest_templates"
+MLFLOW_DEPLOYMENT_NAME = "mlflow"

--- a/src/dss/initialize.py
+++ b/src/dss/initialize.py
@@ -5,14 +5,12 @@ from lightkube import Client
 from lightkube.resources.apps_v1 import Deployment
 from lightkube.resources.core_v1 import Namespace, PersistentVolumeClaim, Service
 
+from dss.config import DSS_CLI_MANAGER_LABELS, FIELD_MANAGER
 from dss.logger import setup_logger
 from dss.utils import wait_for_deployment_ready
 
 # Set up logger
 logger = setup_logger("logs/dss.log")
-
-
-DSS_CLI_MANAGER_LABELS = {"app.kubernetes.io/managed-by": "dss-cli"}
 
 
 def initialize(lightkube_client: Client) -> None:
@@ -30,7 +28,7 @@ def initialize(lightkube_client: Client) -> None:
 
     # Initialize KubernetesResourceHandler
     k8s_resource_handler = KubernetesResourceHandler(
-        field_manager="dss",
+        field_manager=FIELD_MANAGER,
         labels=DSS_CLI_MANAGER_LABELS,
         template_files=[manifests_file],
         context={},

--- a/src/dss/initialize.py
+++ b/src/dss/initialize.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
@@ -26,12 +25,8 @@ def initialize(lightkube_client: Client) -> None:
     """
     # Path to the manifests YAML file
     manifests_files = [
-        Path(
-            Path(__file__).parent, MANIFEST_TEMPLATES_LOCATION, "dss_core.yaml.j2"
-        ),
-        Path(
-            Path(__file__).parent, MANIFEST_TEMPLATES_LOCATION, "mlflow_deployment.yaml.j2"
-        ),
+        Path(Path(__file__).parent, MANIFEST_TEMPLATES_LOCATION, "dss_core.yaml.j2"),
+        Path(Path(__file__).parent, MANIFEST_TEMPLATES_LOCATION, "mlflow_deployment.yaml.j2"),
     ]
     # Initialize KubernetesResourceHandler
     k8s_resource_handler = KubernetesResourceHandler(

--- a/src/dss/initialize.py
+++ b/src/dss/initialize.py
@@ -35,7 +35,7 @@ def initialize(lightkube_client: Client) -> None:
         Path(Path(__file__).parent, MANIFEST_TEMPLATES_LOCATION, "mlflow_deployment.yaml.j2"),
     ]
 
-    config = {"name": MLFLOW_DEPLOYMENT_NAME, "namespace": DSS_NAMESPACE}
+    config = {"mlflow_name": MLFLOW_DEPLOYMENT_NAME, "namespace": DSS_NAMESPACE}
 
     k8s_resource_handler = KubernetesResourceHandler(
         field_manager=FIELD_MANAGER,

--- a/src/dss/initialize.py
+++ b/src/dss/initialize.py
@@ -1,11 +1,12 @@
 import os
+from pathlib import Path
 
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from lightkube import Client
 from lightkube.resources.apps_v1 import Deployment
 from lightkube.resources.core_v1 import Namespace, PersistentVolumeClaim, Service
 
-from dss.config import DSS_CLI_MANAGER_LABELS, FIELD_MANAGER
+from dss.config import DSS_CLI_MANAGER_LABELS, FIELD_MANAGER, MANIFEST_TEMPLATES_LOCATION
 from dss.logger import setup_logger
 from dss.utils import wait_for_deployment_ready
 
@@ -24,13 +25,19 @@ def initialize(lightkube_client: Client) -> None:
         None
     """
     # Path to the manifests YAML file
-    manifests_file = os.path.join(os.path.dirname(__file__), "manifests.yaml")
-
+    manifests_files = [
+        Path(
+            Path(__file__).parent, MANIFEST_TEMPLATES_LOCATION, "dss_core.yaml.j2"
+        ),
+        Path(
+            Path(__file__).parent, MANIFEST_TEMPLATES_LOCATION, "mlflow_deployment.yaml.j2"
+        ),
+    ]
     # Initialize KubernetesResourceHandler
     k8s_resource_handler = KubernetesResourceHandler(
         field_manager=FIELD_MANAGER,
         labels=DSS_CLI_MANAGER_LABELS,
-        template_files=[manifests_file],
+        template_files=manifests_files,
         context={},
         resource_types={Deployment, Service, PersistentVolumeClaim, Namespace},
         lightkube_client=lightkube_client,

--- a/src/dss/initialize.py
+++ b/src/dss/initialize.py
@@ -5,7 +5,13 @@ from lightkube import Client
 from lightkube.resources.apps_v1 import Deployment
 from lightkube.resources.core_v1 import Namespace, PersistentVolumeClaim, Service
 
-from dss.config import DSS_CLI_MANAGER_LABELS, FIELD_MANAGER, MANIFEST_TEMPLATES_LOCATION
+from dss.config import (
+    DSS_CLI_MANAGER_LABELS,
+    DSS_NAMESPACE,
+    FIELD_MANAGER,
+    MANIFEST_TEMPLATES_LOCATION,
+    MLFLOW_DEPLOYMENT_NAME,
+)
 from dss.logger import setup_logger
 from dss.utils import wait_for_deployment_ready
 
@@ -28,12 +34,14 @@ def initialize(lightkube_client: Client) -> None:
         Path(Path(__file__).parent, MANIFEST_TEMPLATES_LOCATION, "dss_core.yaml.j2"),
         Path(Path(__file__).parent, MANIFEST_TEMPLATES_LOCATION, "mlflow_deployment.yaml.j2"),
     ]
-    # Initialize KubernetesResourceHandler
+
+    config = {"name": MLFLOW_DEPLOYMENT_NAME, "namespace": DSS_NAMESPACE}
+
     k8s_resource_handler = KubernetesResourceHandler(
         field_manager=FIELD_MANAGER,
         labels=DSS_CLI_MANAGER_LABELS,
         template_files=manifests_files,
-        context={},
+        context=config,
         resource_types={Deployment, Service, PersistentVolumeClaim, Namespace},
         lightkube_client=lightkube_client,
     )

--- a/src/dss/manifest_templates/dss_core.yaml.j2
+++ b/src/dss/manifest_templates/dss_core.yaml.j2
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ namespace }}
+  labels:
+    app.kubernetes.io/part-of: dss

--- a/src/dss/manifest_templates/mlflow_deployment.yaml.j2
+++ b/src/dss/manifest_templates/mlflow_deployment.yaml.j2
@@ -1,19 +1,12 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: dss
-  labels:
-    app.kubernetes.io/part-of: dss
 
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: mlflow
-  namespace: dss
+  name: {{ name }}
+  namespace: {{ namespace }}
   labels:
-    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/name: {{ name }}
     app.kubernetes.io/part-of: dss
 spec:
   accessModes:
@@ -26,21 +19,21 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mlflow
-  namespace: dss
+  name: {{ name }}
+  namespace: {{ namespace }}
   labels:
-    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/name: {{ name }}
     app.kubernetes.io/part-of: dss
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: mlflow
+      app.kubernetes.io/name: {{ name }}
       app.kubernetes.io/part-of: dss
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: mlflow
+        app.kubernetes.io/name: {{ name }}
         app.kubernetes.io/part-of: dss
     spec:
       containers:
@@ -55,20 +48,20 @@ spec:
       volumes:
         - name: mlflow
           persistentVolumeClaim:
-            claimName: mlflow
+            claimName: {{ name }}
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: mlflow
-  namespace: dss
+  name: {{ name }}
+  namespace: {{ namespace }}
   labels:
-    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/name: {{ name }}
     app.kubernetes.io/part-of: dss
 spec:
   selector:
-    app.kubernetes.io/name: mlflow
+    app.kubernetes.io/name: {{ name }}
     app.kubernetes.io/part-of: dss
   ports:
     - protocol: TCP

--- a/src/dss/manifest_templates/mlflow_deployment.yaml.j2
+++ b/src/dss/manifest_templates/mlflow_deployment.yaml.j2
@@ -3,10 +3,10 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ name }}
+  name: {{ mlflow_name }}
   namespace: {{ namespace }}
   labels:
-    app.kubernetes.io/name: {{ name }}
+    app.kubernetes.io/name: {{ mlflow_name }}
     app.kubernetes.io/part-of: dss
 spec:
   accessModes:
@@ -19,21 +19,21 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ name }}
+  name: {{ mlflow_name }}
   namespace: {{ namespace }}
   labels:
-    app.kubernetes.io/name: {{ name }}
+    app.kubernetes.io/name: {{ mlflow_name }}
     app.kubernetes.io/part-of: dss
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ name }}
+      app.kubernetes.io/name: {{ mlflow_name }}
       app.kubernetes.io/part-of: dss
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ name }}
+        app.kubernetes.io/name: {{ mlflow_name }}
         app.kubernetes.io/part-of: dss
     spec:
       containers:
@@ -48,20 +48,20 @@ spec:
       volumes:
         - name: mlflow
           persistentVolumeClaim:
-            claimName: {{ name }}
+            claimName: {{ mlflow_name }}
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ name }}
+  name: {{ mlflow_name }}
   namespace: {{ namespace }}
   labels:
-    app.kubernetes.io/name: {{ name }}
+    app.kubernetes.io/name: {{ mlflow_name }}
     app.kubernetes.io/part-of: dss
 spec:
   selector:
-    app.kubernetes.io/name: {{ name }}
+    app.kubernetes.io/name: {{ mlflow_name }}
     app.kubernetes.io/part-of: dss
   ports:
     - protocol: TCP

--- a/src/dss/utils.py
+++ b/src/dss/utils.py
@@ -14,6 +14,9 @@ logger = setup_logger("logs/dss.log")
 KUBECONFIG_ENV_VAR = "DSS_KUBECONFIG"
 KUBECONFIG_DEFAULT = "./kubeconfig"
 
+# Labels applied to any Kubernetes objects managed by the DSS CLI
+DSS_CLI_MANAGER_LABELS = {"app.kubernetes.io/managed-by": "dss-cli"}
+
 
 def wait_for_deployment_ready(
     client: Client,

--- a/src/dss/utils.py
+++ b/src/dss/utils.py
@@ -14,9 +14,6 @@ logger = setup_logger("logs/dss.log")
 KUBECONFIG_ENV_VAR = "DSS_KUBECONFIG"
 KUBECONFIG_DEFAULT = "./kubeconfig"
 
-# Labels applied to any Kubernetes objects managed by the DSS CLI
-DSS_CLI_MANAGER_LABELS = {"app.kubernetes.io/managed-by": "dss-cli"}
-
 
 def wait_for_deployment_ready(
     client: Client,

--- a/tests/integration/test_dss.py
+++ b/tests/integration/test_dss.py
@@ -5,7 +5,7 @@ from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from lightkube.resources.apps_v1 import Deployment
 from lightkube.resources.core_v1 import Namespace, PersistentVolumeClaim, Service
 
-from dss.utils import DSS_CLI_MANAGER_LABELS
+from dss.config import DSS_CLI_MANAGER_LABELS
 
 
 def test_initialize_creates_dss(cleanup_after_initialize) -> None:

--- a/tests/integration/test_dss.py
+++ b/tests/integration/test_dss.py
@@ -5,7 +5,7 @@ from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from lightkube.resources.apps_v1 import Deployment
 from lightkube.resources.core_v1 import Namespace, PersistentVolumeClaim, Service
 
-from dss.initialize import DSS_CLI_MANAGER_LABELS
+from dss.utils import DSS_CLI_MANAGER_LABELS
 
 
 def test_initialize_creates_dss(cleanup_after_initialize) -> None:

--- a/tests/unit/test_initialize.py
+++ b/tests/unit/test_initialize.py
@@ -6,15 +6,6 @@ from dss.initialize import initialize
 
 
 @pytest.fixture
-def mock_environ_get() -> MagicMock:
-    """
-    Fixture to mock the os.environ.get function.
-    """
-    with patch("dss.initialize.os.environ.get") as mock_env_get:
-        yield mock_env_get
-
-
-@pytest.fixture
 def mock_client() -> MagicMock:
     """
     Fixture to mock the Client class.
@@ -42,7 +33,6 @@ def mock_logger() -> MagicMock:
 
 
 def test_initialize_success(
-    mock_environ_get: MagicMock,
     mock_client: MagicMock,
     mock_resource_handler: MagicMock,
     mock_logger: MagicMock,


### PR DESCRIPTION
* Moves constants to the shared `config.py` file so their definitions are shared
* moves the `manifests.yaml` for dss's namespace + mlflow deployment to a `manifest_templates` directory and splits the namespace out from the mlflow resources
* adds templating to the existing manifests to remove hardcoded values
* removes a leftover, unused fixture