### PR TITLE
feat: add dss snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,30 @@
+name: dss
+summary: a ML development and experimentation environment manager
+description: |
+     The DSS is a tool that allows users of workstations to deploy
+     and manage development and experimentation environments
+     in systems with GPU support.
+adopt-info: dss
+base: core22
+confinement: strict
+
+parts:
+  dss:
+    plugin: python
+    source: .
+    override-pull: |
+      craftctl default
+      # Comment out after the data-science-stack repository has tags for versioning the snap
+      # craftctl set version=$(git describe --tags --abbrev=10)
+      craftctl set version="0.1"
+plugs:
+  dot-dss-config:
+    interface: personal-files
+    read:
+      - $HOME/.dss/config
+apps:
+  dss:
+    command: bin/dss
+    plugs:
+      - dot-dss-config
+      - network

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,6 +25,4 @@ parts:
     source: .
     override-pull: |
       craftctl default
-      # Comment out after the data-science-stack repository has tags for versioning the snap
-      # craftctl set version=$(git describe --tags --abbrev=10)
-      craftctl set version="0.0"
+      craftctl set version=$(git describe --tags --abbrev=10)

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: dss
-summary: a ML development and experimentation environment manager
+summary: ML development and experimentation environment manager
 description: |
-     The DSS is a tool that allows users of workstations to deploy
+     The DSS is a tool that allows workstations users to deploy
      and manage development and experimentation environments
      in systems with GPU support.
 adopt-info: dss

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,15 +8,6 @@ adopt-info: dss
 base: core22
 confinement: strict
 
-parts:
-  dss:
-    plugin: python
-    source: .
-    override-pull: |
-      craftctl default
-      # Comment out after the data-science-stack repository has tags for versioning the snap
-      # craftctl set version=$(git describe --tags --abbrev=10)
-      craftctl set version="0.1"
 plugs:
   dot-dss-config:
     interface: personal-files
@@ -26,5 +17,14 @@ apps:
   dss:
     command: bin/dss
     plugs:
-      - dot-dss-config
+      - home
       - network
+parts:
+  dss:
+    plugin: python
+    source: .
+    override-pull: |
+      craftctl default
+      # Comment out after the data-science-stack repository has tags for versioning the snap
+      # craftctl set version=$(git describe --tags --abbrev=10)
+      craftctl set version="0.0"


### PR DESCRIPTION
feat: add dss snap project

This commit adds the snap project for DSS.

Fixes #25

#### Testing instructions
1. Clone this repository and build the snap

```
snapcraft
```
2. Install the snap `snap install <name of snap>.snap --dangerous `
3. Run `dss` and see the help printed out:

```
$ dss
Usage: dss [OPTIONS] COMMAND [ARGS]...

  Command line interface for managing the DSS application.

Options:
  --help  Show this message and exit.

Commands:
  create-notebook  Create a Notebook server.
  initialize       Initialize DSS on the given Kubernetes cluster.
```