### PR TITLE
This snap is arch=any so lets only build on amd64

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -7,6 +7,8 @@ description: |
 adopt-info: dss
 base: core22
 confinement: strict
+architectures:
+  - build-on: amd64
 
 plugs:
   dot-dss-config:


### PR DESCRIPTION
No point in building for every arch on every commit using the snapcraft build service.