### PR TITLE
Include all manifests into dss python librarry

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ install_requires =
 include_package_data = True
 
 [options.package_data]
-dss = manifests.yaml
+dss = manifest_templates/*
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
With this fix all the manifests in the dss/manifest_templates folder will be included in the dss librarry. 

This PR fixes a problem mentioned in https://github.com/canonical/data-science-stack/issues/44