### PR TITLE
feat: implement dss status

### DIFF
--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -116,18 +116,19 @@ def logs_command(kubeconfig: str, notebook_name: str, print_all: bool, mlflow: b
     elif notebook_name:
         get_logs("notebooks", notebook_name, lightkube_client)
 
+
 @main.command(name="status")
 @click.option(
     "--kubeconfig",
     help=f"Path to a Kubernetes config file. Defaults to the value of the KUBECONFIG environment variable, else to '{KUBECONFIG_DEFAULT}'.",  # noqa E501
 )
-def logs_command(kubeconfig: str) -> None:
-    """Checks the status of key components within the DSS environment. Verifies if the MLflow deployment is ready and checks if GPU acceleration is enabled on the Kubernetes cluster by examining the labels of Kubernetes nodes for NVIDIA or Intel GPU devices.
-    """
+def status_command(kubeconfig: str) -> None:
+    """Checks the status of key components within the DSS environment. Verifies if the MLflow deployment is ready and checks if GPU acceleration is enabled on the Kubernetes cluster by examining the labels of Kubernetes nodes for NVIDIA or Intel GPU devices."""  # noqa E501
     kubeconfig = get_default_kubeconfig(kubeconfig)
     lightkube_client = get_lightkube_client(kubeconfig)
 
     get_status(lightkube_client)
+
 
 if __name__ == "__main__":
     main()

--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -5,6 +5,7 @@ from dss.create_notebook import create_notebook
 from dss.initialize import initialize
 from dss.logger import setup_logger
 from dss.logs import get_logs
+from dss.status import get_status
 from dss.utils import KUBECONFIG_DEFAULT, get_default_kubeconfig, get_lightkube_client
 
 # Set up logger
@@ -115,6 +116,18 @@ def logs_command(kubeconfig: str, notebook_name: str, print_all: bool, mlflow: b
     elif notebook_name:
         get_logs("notebooks", notebook_name, lightkube_client)
 
+@main.command(name="status")
+@click.option(
+    "--kubeconfig",
+    help=f"Path to a Kubernetes config file. Defaults to the value of the KUBECONFIG environment variable, else to '{KUBECONFIG_DEFAULT}'.",  # noqa E501
+)
+def logs_command(kubeconfig: str) -> None:
+    """Checks the status of key components within the DSS environment. Verifies if the MLflow deployment is ready and checks if GPU acceleration is enabled on the Kubernetes cluster by examining the labels of Kubernetes nodes for NVIDIA or Intel GPU devices.
+    """
+    kubeconfig = get_default_kubeconfig(kubeconfig)
+    lightkube_client = get_lightkube_client(kubeconfig)
+
+    get_status(lightkube_client)
 
 if __name__ == "__main__":
     main()

--- a/src/dss/status.py
+++ b/src/dss/status.py
@@ -45,6 +45,4 @@ def get_status(lightkube_client: Client) -> None:
             logger.info("GPU acceleration: Disabled")
     except Exception as e:
         logger.error(f"Failed to retrieve status: {e}")
-        logger.info("MLflow deployment: Not ready")
-        logger.info("GPU acceleration: Not detected")
         return

--- a/src/dss/status.py
+++ b/src/dss/status.py
@@ -1,2 +1,47 @@
-def get_status(lightkube_client):
-    pass
+from lightkube import Client
+
+from dss.config import DSS_NAMESPACE, MLFLOW_DEPLOYMENT_NAME
+from dss.logger import setup_logger
+from dss.utils import does_mlflow_deployment_exist, get_labels_for_node, get_service_url
+
+# Set up logger
+logger = setup_logger("logs/dss.log")
+
+
+def get_status(lightkube_client: Client):
+    """
+    Checks the status of key components within the DSS environment.
+
+    Args:
+        lightkube_client (Client): The Kubernetes client.
+    """
+    try:
+        # Check MLflow deployment
+        mlflow_ready = does_mlflow_deployment_exist(lightkube_client)
+
+        # Log MLflow deployment status and URL
+        if mlflow_ready:
+            mlflow_url = get_service_url(MLFLOW_DEPLOYMENT_NAME, DSS_NAMESPACE, lightkube_client)
+            logger.info("MLflow deployment: Ready")
+            logger.info(f"MLflow URL: {mlflow_url}")
+        else:
+            logger.info("MLflow deployment: Not ready")
+
+        # Check NVIDIA GPU acceleration
+        gpu_acceleration = False
+        node_labels = get_labels_for_node(lightkube_client)
+        if (
+            "nvidia.com/gpu.present" in node_labels
+            and "nvidia.com/gpu.deploy.container-toolkit" in node_labels
+            and "nvidia.com/gpu.deploy.device-plugin" in node_labels
+        ):
+            gpu_acceleration = True
+
+        # Log GPU status
+        if gpu_acceleration:
+            logger.info("GPU acceleration: Enabled (NVIDIA GPU)")
+        else:
+            logger.info("GPU acceleration: Disabled")
+    except Exception as e:
+        logger.error(f"Failed to retrieve status: {e}")
+        return

--- a/src/dss/status.py
+++ b/src/dss/status.py
@@ -8,9 +8,9 @@ from dss.utils import does_mlflow_deployment_exist, get_labels_for_node, get_ser
 logger = setup_logger("logs/dss.log")
 
 
-def get_status(lightkube_client: Client):
+def get_status(lightkube_client: Client) -> None:
     """
-    Checks the status of key components within the DSS environment.
+    Logs  the status of key components within the DSS environment.
 
     Args:
         lightkube_client (Client): The Kubernetes client.
@@ -36,12 +36,15 @@ def get_status(lightkube_client: Client):
             and "nvidia.com/gpu.deploy.device-plugin" in node_labels
         ):
             gpu_acceleration = True
+            card_name = node_labels.get("nvidia.com/gpu.product", "NVIDIA GPU")
 
         # Log GPU status
         if gpu_acceleration:
-            logger.info("GPU acceleration: Enabled (NVIDIA GPU)")
+            logger.info(f"GPU acceleration: Enabled ({card_name})")
         else:
             logger.info("GPU acceleration: Disabled")
     except Exception as e:
         logger.error(f"Failed to retrieve status: {e}")
+        logger.info("MLflow deployment: Not ready")
+        logger.info("GPU acceleration: Not detected")
         return

--- a/src/dss/status.py
+++ b/src/dss/status.py
@@ -1,0 +1,2 @@
+def get_status(lightkube_client):
+    pass

--- a/src/dss/utils.py
+++ b/src/dss/utils.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from lightkube import ApiError, Client, KubeConfig
 from lightkube.resources.apps_v1 import Deployment
-from lightkube.resources.core_v1 import PersistentVolumeClaim, Pod, Service
+from lightkube.resources.core_v1 import Node, PersistentVolumeClaim, Pod, Service
 
 from dss.config import DSS_NAMESPACE, MLFLOW_DEPLOYMENT_NAME, NOTEBOOK_PVC_NAME
 from dss.logger import setup_logger
@@ -194,3 +194,20 @@ def does_mlflow_deployment_exist(lightkube_client: Client) -> bool:
         else:
             # Something went wrong
             raise e
+
+
+def get_labels_for_node(lightkube_client: Client) -> dict:
+    """
+    Get the labels of the only node in the cluster.
+
+    Args:
+        lightkube_client (Client): The Kubernetes client.
+
+    Returns:
+        dict: A dictionary containing labels of the node matching the gpu_type.
+    """
+    nodes = list(lightkube_client.list(Node))
+    if len(nodes) != 1:
+        raise ValueError("Expected exactly one node in the cluster")
+
+    return nodes[0].metadata.labels

--- a/tests/integration/test_dss.py
+++ b/tests/integration/test_dss.py
@@ -8,6 +8,8 @@ from lightkube.resources.core_v1 import Namespace, PersistentVolumeClaim, Servic
 
 from dss.config import DSS_CLI_MANAGER_LABELS, DSS_NAMESPACE, FIELD_MANAGER
 
+# TODO: is there a better way to initialize this?  Maybe an optional argument to the test?
+KUBECONFIG = "~/.kube/config"
 NOTEBOOK_RESOURCES_FILE = "./tests/integration/notebook-resources.yaml"
 NOTEBOOK_NAME = "test-nb"
 
@@ -16,11 +18,10 @@ def test_status_before_initialize(cleanup_after_initialize) -> None:
     """
     Integration test to verify 'dss status' command before initialization.
     """
-    kubeconfig = "~/.kube/config"
 
     # Run the status command
     result = subprocess.run(
-        ["dss", "status", "--kubeconfig", kubeconfig], capture_output=True, text=True
+        ["dss", "status", "--kubeconfig", KUBECONFIG], capture_output=True, text=True
     )
 
     # Check if the command executed successfully
@@ -38,11 +39,8 @@ def test_initialize_creates_dss(cleanup_after_initialize) -> None:
     Integration test to verify if the initialize command creates the 'dss' namespace and
     the 'mlflow' deployment is active in the 'dss' namespace.
     """
-    # TODO: is there a better way to initialize this?  Maybe an optional argument to the test?
-    kubeconfig = "~/.kube/config"
-
     result = subprocess.run(
-        ["dss", "initialize", "--kubeconfig", kubeconfig],
+        ["dss", "initialize", "--kubeconfig", KUBECONFIG],
         capture_output=True,
         text=True,
     )
@@ -81,9 +79,7 @@ def test_create_notebook(cleanup_after_initialize) -> None:
 
     Must be run after `dss initialize`
     """
-    # TODO: is there a better way to initialize this?  Maybe an optional argument to the test?
-    kubeconfig_file = "~/.kube/config"
-    kubeconfig = lightkube.KubeConfig.from_file(kubeconfig_file)
+    kubeconfig = lightkube.KubeConfig.from_file(KUBECONFIG)
     lightkube_client = lightkube.Client(kubeconfig)
 
     notebook_image = "kubeflownotebookswg/jupyter-scipy:v1.8.0"
@@ -96,7 +92,7 @@ def test_create_notebook(cleanup_after_initialize) -> None:
             "--image",
             notebook_image,
             "--kubeconfig",
-            kubeconfig_file,
+            KUBECONFIG,
         ],
         capture_output=True,
         text=True,
@@ -116,11 +112,9 @@ def test_status_after_initialize(cleanup_after_initialize) -> None:
     """
     Integration test to verify 'dss status' command before initialization.
     """
-    kubeconfig = "~/.kube/config"
-
     # Run the status command
     result = subprocess.run(
-        ["dss", "status", "--kubeconfig", kubeconfig], capture_output=True, text=True
+        ["dss", "status", "--kubeconfig", KUBECONFIG], capture_output=True, text=True
     )
 
     # Check if the command executed successfully
@@ -137,8 +131,6 @@ def test_log_command(cleanup_after_initialize) -> None:
     """
     Integration test for the 'logs' command.
     """
-    kubeconfig_file = "~/.kube/config"
-
     # Run the logs command with the notebook name and kubeconfig file
     result = subprocess.run(
         [
@@ -146,7 +138,7 @@ def test_log_command(cleanup_after_initialize) -> None:
             "logs",
             NOTEBOOK_NAME,
             "--kubeconfig",
-            kubeconfig_file,
+            KUBECONFIG,
         ],
         capture_output=True,
         text=True,
@@ -160,7 +152,7 @@ def test_log_command(cleanup_after_initialize) -> None:
 
     # Run the logs command for MLflow with the kubeconfig file
     result = subprocess.run(
-        ["dss", "logs", "--mlflow", "--kubeconfig", kubeconfig_file],
+        ["dss", "logs", "--mlflow", "--kubeconfig", KUBECONFIG],
         capture_output=True,
         text=True,
     )

--- a/tests/integration/test_dss.py
+++ b/tests/integration/test_dss.py
@@ -12,6 +12,27 @@ NOTEBOOK_RESOURCES_FILE = "./tests/integration/notebook-resources.yaml"
 NOTEBOOK_NAME = "test-nb"
 
 
+def test_status_before_initialize(cleanup_after_initialize) -> None:
+    """
+    Integration test to verify 'dss status' command before initialization.
+    """
+    kubeconfig = "~/.kube/config"
+
+    # Run the status command
+    result = subprocess.run(
+        ["dss", "status", "--kubeconfig", kubeconfig], capture_output=True, text=True
+    )
+
+    # Check if the command executed successfully
+    assert result.returncode == 0
+
+    # Check if the output indicates MLflow deployment is not ready
+    assert "MLflow deployment: Not ready" in result.stderr
+
+    # Check if the output indicates GPU acceleration is disabled
+    assert "GPU acceleration: Disabled" in result.stderr
+
+
 def test_initialize_creates_dss(cleanup_after_initialize) -> None:
     """
     Integration test to verify if the initialize command creates the 'dss' namespace and
@@ -89,6 +110,27 @@ def test_create_notebook(cleanup_after_initialize) -> None:
     # Check if the notebook deployment is active in the dss namespace
     deployment = lightkube_client.get(Deployment, name=NOTEBOOK_NAME, namespace=DSS_NAMESPACE)
     assert deployment.status.availableReplicas == deployment.spec.replicas
+
+
+def test_status_after_initialize(cleanup_after_initialize) -> None:
+    """
+    Integration test to verify 'dss status' command before initialization.
+    """
+    kubeconfig = "~/.kube/config"
+
+    # Run the status command
+    result = subprocess.run(
+        ["dss", "status", "--kubeconfig", kubeconfig], capture_output=True, text=True
+    )
+
+    # Check if the command executed successfully
+    assert result.returncode == 0
+
+    # Check if the output indicates MLflow deployment is ready
+    assert "MLflow deployment: Ready" in result.stderr
+
+    # Check if the output indicates GPU acceleration is enabled
+    assert "GPU acceleration: Disabled" in result.stderr
 
 
 def test_log_command(cleanup_after_initialize) -> None:

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,3 +1,6 @@
+from typing import Dict, List
+from unittest.mock import MagicMock
+
 import pytest
 
 from dss.status import get_status
@@ -34,7 +37,11 @@ from dss.status import get_status
     ],
 )
 def test_get_status_with_different_scenarios(
-    mocker, mlflow_exist, mlflow_url, gpu_labels, expected_logs
+    mocker: MagicMock,
+    mlflow_exist: bool,
+    mlflow_url: str,
+    gpu_labels: Dict[str, str],
+    expected_logs: List[str],
 ):
     """
     Test case to verify different scenarios of MLflow deployment and GPU acceleration status.

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -16,11 +16,12 @@ from dss.status import get_status
                 "nvidia.com/gpu.present": "true",
                 "nvidia.com/gpu.deploy.container-toolkit": "true",
                 "nvidia.com/gpu.deploy.device-plugin": "true",
+                "nvidia.com/gpu.product": "Test-GPU",
             },
             [
                 "MLflow deployment: Ready",
                 "MLflow URL: <Mocked MLflow URL>",
-                "GPU acceleration: Enabled (NVIDIA GPU)",
+                "GPU acceleration: Enabled (Test-GPU)",
             ],
         ),
         (

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,0 +1,55 @@
+import pytest
+
+from dss.status import get_status
+
+
+@pytest.mark.parametrize(
+    "mlflow_exist, mlflow_url, gpu_labels, expected_logs",
+    [
+        (
+            True,
+            "<Mocked MLflow URL>",
+            {
+                "nvidia.com/gpu.present": "true",
+                "nvidia.com/gpu.deploy.container-toolkit": "true",
+                "nvidia.com/gpu.deploy.device-plugin": "true",
+            },
+            [
+                "MLflow deployment: Ready",
+                "MLflow URL: <Mocked MLflow URL>",
+                "GPU acceleration: Enabled (NVIDIA GPU)",
+            ],
+        ),
+        (
+            True,
+            "<Mocked MLflow URL>",
+            {},
+            [
+                "MLflow deployment: Ready",
+                "MLflow URL: <Mocked MLflow URL>",
+                "GPU acceleration: Disabled",
+            ],
+        ),
+        (False, None, {}, ["MLflow deployment: Not ready", "GPU acceleration: Disabled"]),
+    ],
+)
+def test_get_status_with_different_scenarios(
+    mocker, mlflow_exist, mlflow_url, gpu_labels, expected_logs
+):
+    """
+    Test case to verify different scenarios of MLflow deployment and GPU acceleration status.
+    """
+    # Mock the functions
+    mocker.patch("dss.status.does_mlflow_deployment_exist", return_value=mlflow_exist)
+    mocker.patch("dss.status.get_service_url", return_value=mlflow_url)
+    mocker.patch("dss.status.get_labels_for_node", return_value=gpu_labels)
+
+    # Mock the logger
+    mock_logger = mocker.patch("dss.status.logger")
+
+    # Call the function to test
+    get_status(None)  # Pass None as the client argument since it's not used in this test case
+
+    # Assertions
+    for log_message in expected_logs:
+        mock_logger.info.assert_any_call(log_message)


### PR DESCRIPTION
Resolves: https://github.com/canonical/data-science-stack/issues/67

The nvidia gpu status was tested only on my local machine as the runners don't have gpus.

**Steps to test locally:** 
Install and setup microk8s 
```
sudo snap install microk8s --channel=1.28/stable --classic
microk8s enable storage dns rbac gpu
microk8s config > ~/.kube/config
```

Run dss
```
export KUBECONFIG=~/.kube/config

pip install .
dss initialize --kubeconfig $KUBECONFIG
dss status
```