### PR TITLE
feat: Implement `dss purge` command

### DIFF
--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -212,6 +212,7 @@ def remove_notebook_command(name: str, kubeconfig: str):
     except RuntimeError:
         exit(1)
 
+
 @main.command(name="purge")
 @click.option(
     "--kubeconfig",
@@ -238,6 +239,9 @@ def purge_command(kubeconfig: str) -> None:
         logger.info("  dss status      to check the current status")
         logger.info("  dss logs --all  to review all logs")
         logger.info("  dss initialize  to install dss")
+        exit(1)
+    except Exception as err:
+        logger.error(f"An error occurred: {err}")
         exit(1)
 
 if __name__ == "__main__":

--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -223,25 +223,16 @@ def purge_command(kubeconfig: str) -> None:
     """
     Removes all notebooks and DSS components.
     """
-    logger.info("Executing purge command")
-
-    kubeconfig = get_default_kubeconfig(kubeconfig)
-    lightkube_client = get_lightkube_client(kubeconfig)
     try:
+        kubeconfig = get_default_kubeconfig(kubeconfig)
+        lightkube_client = get_lightkube_client(kubeconfig)
         purge(lightkube_client=lightkube_client)
-    except ApiError as err:
-        logger.error(
-            f"Failed to purge DSS components with error code {err.status.code}. Please try again."
-        )
-        logger.debug(f"Failed to purge DSS components with error {err}.")
-        logger.info("You might want to run")
-        logger.info("  dss status      to check the current status")
-        logger.info("  dss logs --all  to review all logs")
-        logger.info("  dss initialize  to install dss")
-        exit(1)
-    except Exception as err:
-        logger.error(f"An error occurred: {err}")
-        exit(1)
+    except RuntimeError:
+        click.get_current_context().exit(1)
+    except Exception as e:
+        logger.debug(f"Failed to purge DSS components: {e}.", exc_info=True)
+        logger.error(f"Failed to purge DSS components: {str(e)}.")
+        click.get_current_context().exit(1)
 
 
 if __name__ == "__main__":

--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -1,17 +1,16 @@
 import click
 from lightkube.core.exceptions import ApiError
 
-from lightkube.core.exceptions import ApiError
 from dss.config import DEFAULT_NOTEBOOK_IMAGE, RECOMMENDED_IMAGES_MESSAGE
 from dss.create_notebook import create_notebook
 from dss.initialize import initialize
 from dss.list import list_notebooks
 from dss.logger import setup_logger
 from dss.logs import get_logs
+from dss.purge import purge
 from dss.remove_notebook import remove_notebook
 from dss.status import get_status
 from dss.stop import stop_notebook
-from dss.purge import purge
 from dss.utils import KUBECONFIG_DEFAULT, get_default_kubeconfig, get_lightkube_client
 
 # Set up logger
@@ -243,6 +242,7 @@ def purge_command(kubeconfig: str) -> None:
     except Exception as err:
         logger.error(f"An error occurred: {err}")
         exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/src/dss/purge.py
+++ b/src/dss/purge.py
@@ -1,4 +1,4 @@
-from lightkube import Client, ApiError
+from lightkube import ApiError, Client
 from lightkube.resources.core_v1 import Namespace
 
 from dss.config import DSS_NAMESPACE
@@ -35,7 +35,7 @@ def purge(lightkube_client: Client) -> None:
         except ApiError as err:
             logger.debug(f"Failed to purge DSS components: {err}.")
             logger.error(
-                f"Failed to purge DSS components with error code {err.status.code}. Please try again."
+                f"Failed to purge DSS components with error code {err.status.code}. Please try again."  # noqa E501
             )
             logger.info("You might want to run")
             logger.info("  dss status      to check the current status")

--- a/src/dss/purge.py
+++ b/src/dss/purge.py
@@ -1,0 +1,33 @@
+from lightkube import Client
+from lightkube.resources.core_v1 import Namespace
+
+from dss.config import DSS_NAMESPACE
+from dss.logger import setup_logger
+from dss.utils import does_namespace_exist, wait_for_namespace_to_be_deleted
+
+# Set up logger
+logger = setup_logger("logs/dss.log")
+
+
+def purge(lightkube_client: Client) -> None:
+    """
+    Removes all notebooks and DSS components. This is done by removing the
+    `dss` namespace, and thus all resources living in that namespace.
+
+    Args:
+        lightkube_client (Client): The Kubernetes client.
+    """
+    if not does_namespace_exist(lightkube_client, DSS_NAMESPACE):
+        logger.warn(f"Cannot purge DSS components. Namespace `{DSS_NAMESPACE}` does not exist.")
+        logger.info("You might want to run")
+        logger.info("  dss status      to check the current status")
+        logger.info("  dss logs --all  to review all logs")
+        logger.info("  dss initialize  to install dss")
+        return
+    else:
+        lightkube_client.delete(Namespace, DSS_NAMESPACE)
+        # need to wait on namespace deletion to be completed
+        wait_for_namespace_to_be_deleted(lightkube_client, DSS_NAMESPACE)
+        logger.info(
+            "Success: All DSS components and notebooks purged successfully from the Kubernetes cluster."  # noqa E501
+        )

--- a/tests/integration/test_dss.py
+++ b/tests/integration/test_dss.py
@@ -224,11 +224,6 @@ def test_remove_notebook(cleanup_after_initialize) -> None:
     Tests that `dss remove` successfully removes a notebook as expected.
     Must be run after `dss initialize`
     """
-    # FIXME: remove the `--kubeconfig`` option
-    # after fixing https://github.com/canonical/data-science-stack/issues/37
-    kubeconfig_file = "~/.kube/config"
-    kubeconfig = lightkube.KubeConfig.from_file(kubeconfig_file)
-    lightkube_client = lightkube.Client(kubeconfig)
 
     result = subprocess.run(
         [
@@ -236,10 +231,15 @@ def test_remove_notebook(cleanup_after_initialize) -> None:
             "remove",
             NOTEBOOK_NAME,
             "--kubeconfig",
-            kubeconfig_file,
+            KUBECONFIG,
         ]
     )
     assert result.returncode == 0
+
+    # FIXME: remove the `--kubeconfig`` option
+    # after fixing https://github.com/canonical/data-science-stack/issues/37
+    kubeconfig = lightkube.KubeConfig.from_file(KUBECONFIG)
+    lightkube_client = lightkube.Client(kubeconfig)
 
     # Check if the notebook Deployment is not found in the namespace
     with pytest.raises(ApiError) as err:
@@ -287,6 +287,7 @@ def test_purge(cleanup_after_initialize) -> None:
 @pytest.fixture(scope="module")
 def cleanup_after_initialize():
     """Cleans up resources that might have been deployed by dss initialize.
+
     Note that this is a white-box implementation - it depends on knowing what could be deployed and
     explicitly removing those objects, rather than truly restoring the cluster to a previous state.
     This could be leaky, depending on how `dss` is changed in future.  Hopefully though, by cleaning

--- a/tests/integration/test_dss.py
+++ b/tests/integration/test_dss.py
@@ -84,8 +84,6 @@ def test_create_notebook(cleanup_after_initialize) -> None:
     kubeconfig = lightkube.KubeConfig.from_file(KUBECONFIG)
     lightkube_client = lightkube.Client(kubeconfig)
 
-    notebook_image = "kubeflownotebookswg/jupyter-scipy:v1.8.0"
-
     result = subprocess.run(
         [
             DSS_NAMESPACE,

--- a/tests/integration/test_dss.py
+++ b/tests/integration/test_dss.py
@@ -81,6 +81,9 @@ def test_create_notebook(cleanup_after_initialize) -> None:
 
     Must be run after `dss initialize`
     """
+    kubeconfig = lightkube.KubeConfig.from_file(KUBECONFIG)
+    lightkube_client = lightkube.Client(kubeconfig)
+
     notebook_image = "kubeflownotebookswg/jupyter-scipy:v1.8.0"
 
     result = subprocess.run(
@@ -103,8 +106,6 @@ def test_create_notebook(cleanup_after_initialize) -> None:
     assert result.returncode == 0
 
     # Check if the notebook deployment is active in the dss namespace
-    kubeconfig = lightkube.KubeConfig.from_file(KUBECONFIG)
-    lightkube_client = lightkube.Client(kubeconfig)
     deployment = lightkube_client.get(Deployment, name=NOTEBOOK_NAME, namespace=DSS_NAMESPACE)
     assert deployment.status.availableReplicas == deployment.spec.replicas
 
@@ -195,6 +196,8 @@ def test_stop_notebook(cleanup_after_initialize) -> None:
 
     Must be run after `dss create`.
     """
+    kubeconfig = lightkube.KubeConfig.from_file(KUBECONFIG)
+    lightkube_client = lightkube.Client(kubeconfig)
 
     # Run the stop command with the notebook name and kubeconfig file
     result = subprocess.run(
@@ -213,8 +216,6 @@ def test_stop_notebook(cleanup_after_initialize) -> None:
     assert result.returncode == 0
 
     # Check the notebook deployment was scaled down to 0
-    kubeconfig = lightkube.KubeConfig.from_file(KUBECONFIG)
-    lightkube_client = lightkube.Client(kubeconfig)
     deployment = lightkube_client.get(Deployment, name=NOTEBOOK_NAME, namespace=DSS_NAMESPACE)
     assert deployment.spec.replicas == 0
 
@@ -224,6 +225,10 @@ def test_remove_notebook(cleanup_after_initialize) -> None:
     Tests that `dss remove` successfully removes a notebook as expected.
     Must be run after `dss initialize`
     """
+    # FIXME: remove the `--kubeconfig`` option
+    # after fixing https://github.com/canonical/data-science-stack/issues/37
+    kubeconfig = lightkube.KubeConfig.from_file(KUBECONFIG)
+    lightkube_client = lightkube.Client(kubeconfig)
 
     result = subprocess.run(
         [
@@ -235,11 +240,6 @@ def test_remove_notebook(cleanup_after_initialize) -> None:
         ]
     )
     assert result.returncode == 0
-
-    # FIXME: remove the `--kubeconfig`` option
-    # after fixing https://github.com/canonical/data-science-stack/issues/37
-    kubeconfig = lightkube.KubeConfig.from_file(KUBECONFIG)
-    lightkube_client = lightkube.Client(kubeconfig)
 
     # Check if the notebook Deployment is not found in the namespace
     with pytest.raises(ApiError) as err:

--- a/tests/unit/test_create_notebook.py
+++ b/tests/unit/test_create_notebook.py
@@ -226,7 +226,7 @@ def test_create_notebook_failure_time_out(
     mock_client_instance = MagicMock()
 
     # Mock the behavior of wait_for_deployment_ready
-    mock_wait_for_deployment_ready.side_effect = TimeoutError("test-excpetion-message")
+    mock_wait_for_deployment_ready.side_effect = TimeoutError("test-exception-message")
 
     with patch("dss.create_notebook.does_dss_pvc_exist", return_value=True), patch(
         "dss.create_notebook.does_notebook_exist", return_value=False

--- a/tests/unit/test_purge.py
+++ b/tests/unit/test_purge.py
@@ -1,0 +1,94 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from test_utils import FakeApiError
+
+from dss.config import DSS_NAMESPACE
+from dss.purge import purge
+
+
+@pytest.fixture
+def mock_does_namespace_exist() -> MagicMock:
+    """
+    Fixture to mock the get_service_url function.
+    """
+    with patch("dss.purge.does_namespace_exist") as mock_does_namespace_exist:
+        yield mock_does_namespace_exist
+
+
+@pytest.fixture
+def mock_wait_for_namespace_to_be_deleted() -> MagicMock:
+    """
+    Fixture to mock the KubernetesResourceHandler class.
+    """
+    with patch(
+        "dss.purge.wait_for_namespace_to_be_deleted"
+    ) as mock_wait_for_namespace_to_be_deleted:
+        yield mock_wait_for_namespace_to_be_deleted
+
+
+@pytest.fixture
+def mock_logger() -> MagicMock:
+    """
+    Fixture to mock the logger object.
+    """
+    with patch("dss.purge.logger") as mock_logger:
+        yield mock_logger
+
+
+def test_purge_success(
+    mock_logger: MagicMock,
+    mock_does_namespace_exist: MagicMock,
+    mock_wait_for_namespace_to_be_deleted: MagicMock,
+) -> None:
+    """
+    Test case to verify behavior on success.
+    """
+    mock_does_namespace_exist.return_value = True
+    mock_client_instance = MagicMock()
+    purge(mock_client_instance)
+
+    # Assertions
+    mock_logger.info.assert_called_with(
+        "Success: All DSS components and notebooks purged successfully from the Kubernetes cluster."  # noqa E501
+    )
+    mock_logger.error.assert_not_called()
+    mock_logger.warn.assert_not_called()
+    mock_logger.debug.assert_not_called()
+
+
+def test_purge_failure_namespace_does_not_exist(
+    mock_logger: MagicMock, mock_does_namespace_exist: MagicMock
+) -> None:
+    """
+    Test case to verify behavior when `dss` namespace does not exist.
+    """
+    mock_does_namespace_exist.return_value = False
+    mock_client_instance = MagicMock()
+    purge(mock_client_instance)
+
+    # Assertions
+    mock_logger.warn.assert_called_with(
+        f"Cannot purge DSS components. Namespace `{DSS_NAMESPACE}` does not exist."
+    )
+    mock_logger.info.assert_any_call("You might want to run")
+    mock_logger.info.assert_any_call("  dss status      to check the current status")
+    mock_logger.info.assert_any_call("  dss logs --all  to review all logs")
+    mock_logger.info.assert_called_with("  dss initialize  to install dss")
+    mock_logger.error.assert_not_called()
+    mock_logger.debug.assert_not_called()
+
+
+def test_purge_failure_api_error(mock_does_namespace_exist: MagicMock) -> None:
+    """
+    Test case to verify that ApiError is handled.
+    """
+    mock_does_namespace_exist.return_value = True
+    mock_client_instance = MagicMock()
+    error_code = 400
+    mock_client_instance.delete.side_effect = FakeApiError(error_code)
+    with pytest.raises(FakeApiError) as exc_info:
+        purge(mock_client_instance)
+
+    # Assertions
+    assert str(exc_info.value) == "broken"

--- a/tests/unit/test_purge.py
+++ b/tests/unit/test_purge.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from test_utils import FakeApiError
 
 from dss.config import DSS_NAMESPACE
 from dss.purge import purge
@@ -89,6 +88,7 @@ def test_purge_failure_runtime_error(mock_does_namespace_exist: MagicMock) -> No
     mock_client_instance.delete.side_effect = RuntimeError()
     with pytest.raises(RuntimeError):
         purge(mock_client_instance)
+
 
 def test_purge_failure_not_runtime_error(mock_does_namespace_exist: MagicMock) -> None:
     """


### PR DESCRIPTION
* Implement `dss purge` command
* Use `dss purge` to clean up integration tests (and thus test that it
 works as expected).
* Add unit tests for `purge` function and helper functions.

Closes #34

### Testing
Given that microk8s is already installed, run dss
```
git checkout origin/kf-5383-feat-dss-purge-command
pip install .
dss initialize --kubeconfig ~/.kube/config
dss create test-notebook
# verify resources (mlflow deployment, notebook pods and pvcs) 
dss purge --kubeconfig ~/.kube/config
# verify resources (everything has been deleted)
```

#### Verify resources in dss namespace
```bash
kubectl get ns
kubectl get po -n dss
kubectl get pvc -n dss
```