### PR TITLE
Refactor `dss` commands exit codes and logging

### DIFF
--- a/src/dss/create_notebook.py
+++ b/src/dss/create_notebook.py
@@ -42,24 +42,22 @@ def create_notebook(name: str, image: str, lightkube_client: Client) -> None:
     if not does_dss_pvc_exist(lightkube_client) or not does_mlflow_deployment_exist(
         lightkube_client
     ):
-        logger.error("Failed to create notebook. DSS was not correctly initialized.\n")
-        logger.info(
-            "You might want to run\n"
-            "  dss status      to check the current status\n"
-            "  dss logs --all  to review all logs\n"
-            "  dss initialize  to install dss\n"
-        )
-        return
+        logger.debug("Failed to create notebook. DSS was not correctly initialized.")
+        logger.error("Failed to create notebook. DSS was not correctly initialized.")
+        logger.info("Note: You might want to run")
+        logger.info("  dss status      to check the current status")
+        logger.info("  dss logs --all  to view all logs")
+        logger.info("  dss initialize  to install dss")
+        raise RuntimeError()
     if does_notebook_exist(name, DSS_NAMESPACE, lightkube_client):
         # Assumes that the notebook server is exposed by a service of the same name.
-        logger.error(
-            f"Failed to create Notebook. Notebook with name '{name}' already exists.\n"
-            f"Please specify a different name."
-        )
+        logger.debug(f"Failed to create Notebook. Notebook with name '{name}' already exists.")
+        logger.error(f"Failed to create Notebook. Notebook with name '{name}' already exists.")
+        logger.info("Please specify a different name.")
         url = get_service_url("name", DSS_NAMESPACE, lightkube_client)
         if url:
             logger.info(f"To connect to the existing notebook, go to {url}.")
-        return
+        raise RuntimeError()
 
     manifests_file = Path(
         Path(__file__).parent, MANIFEST_TEMPLATES_LOCATION, "notebook_deployment.yaml.j2"
@@ -85,30 +83,25 @@ def create_notebook(name: str, image: str, lightkube_client: Client) -> None:
 
         logger.info(f"Success: Notebook {name} created successfully.")
     except ApiError as err:
-        logger.error(
-            f"Failed to create Notebook with error code {err.status.code}."
-            " Check the debug logs for more details."
-        )
-        logger.debug(f"Failed to create Notebook {name} with error {err}")
-        return
+        logger.debug(f"Failed to create Notebook {name}: {err}.", exc_info=True)
+        logger.error(f"Failed to create Notebook with error code {err.status.code}.")
+        logger.info(" Check the debug logs for more details.")
+        raise RuntimeError()
     except TimeoutError as err:
-        logger.error(str(err))
-        logger.warn(
-            f"Timed out while trying to create Notebook {name}.\n"
-            "Some resources might be left in the cluster. Check the status with `dss list`."
-        )
-        return
+        logger.debug(f"Failed to create Notebook {name}: {err}", exc_info=True)
+        logger.error(f"Timed out while trying to create Notebook {name}.")
+        logger.warn(" Some resources might be left in the cluster.")
+        logger.info(" Check the status with `dss list`.")
+        raise RuntimeError()
     except ImagePullBackOffError as err:
-        logger.error(
-            f"Timed out while trying to create Notebook {name}.\n"
-            f"Image {image_full_name} does not exist or is not accessible.\n"
-        )
+        logger.debug(f"Timed out while trying to create Notebook {name}: {err}.", exc_info=True)
+        logger.error(f"Timed out while trying to create Notebook {name}.")
+        logger.error(f"Image {image_full_name} does not exist or is not accessible.")
         logger.info(
             "Note: You might want to use some of these recommended images:\n"
             f"{RECOMMENDED_IMAGES_MESSAGE}"
         )
-        logger.debug(f"Timed out while trying to create Notebook {name} with error {err}.")
-        return
+        raise RuntimeError()
     # Assumes that the notebook server is exposed by a service of the same name.
     url = get_service_url(name, DSS_NAMESPACE, lightkube_client)
     if url:

--- a/src/dss/logs.py
+++ b/src/dss/logs.py
@@ -50,7 +50,7 @@ def get_logs(parts: str, name: str, lightkube_client: Client) -> None:
                     labels=mlflow_deployment.spec.selector.matchLabels,
                 )
             except ApiError as e:
-                logger.debug(f"Failed to retrieve logs for MLflow: {e}")
+                logger.debug(f"Failed to retrieve logs for MLflow: {e}", exc_info=True)
                 logger.error(
                     "Failed to retrieve logs. MLflow seems to be not present. Make sure DSS is correctly initialized."  # noqa: E501
                 )

--- a/src/dss/logs.py
+++ b/src/dss/logs.py
@@ -30,9 +30,12 @@ def get_logs(parts: str, name: str, lightkube_client: Client) -> None:
                 if deployment.metadata.name == name:
                     break
             else:
+                logger.debug(
+                    f"Failed to retrieve logs. Deployment '{name}' does not exist in {DSS_NAMESPACE} namespace."  # noqa E501
+                )
                 logger.error(f"Failed to retrieve logs. Notebook '{name}' does not exist.")
                 logger.info("Run 'dss list' to check all notebooks.")
-                return
+                raise RuntimeError()
             pods = lightkube_client.list(
                 Pod, namespace=DSS_NAMESPACE, labels=deployment.spec.selector.matchLabels
             )
@@ -46,15 +49,16 @@ def get_logs(parts: str, name: str, lightkube_client: Client) -> None:
                     namespace=DSS_NAMESPACE,
                     labels=mlflow_deployment.spec.selector.matchLabels,
                 )
-            except ApiError:
+            except ApiError as e:
+                logger.debug(f"Failed to retrieve logs for MLflow: {e}")
                 logger.error(
-                    "Failed to retrieve logs. MLflow seems to be not present.Make sure DSS is correctly initialized."  # noqa: E501
+                    "Failed to retrieve logs. MLflow seems to be not present. Make sure DSS is correctly initialized."  # noqa: E501
                 )
                 logger.info("Note: You might want to run")
                 logger.info("  dss status      to check the current status")
                 logger.info("  dss logs --all  to view all logs")
                 logger.info("  dss initialize  to install dss")
-                return
+                raise RuntimeError()
         elif parts == "all":
             deployments = list(lightkube_client.list(Deployment, namespace=DSS_NAMESPACE))
             pods = []
@@ -65,18 +69,19 @@ def get_logs(parts: str, name: str, lightkube_client: Client) -> None:
                     )
                 )
     except ApiError as e:
-        logger.error(e)
+        logger.debug(f"Failed to retrieve logs for {parts} {name}: {e}", exc_info=True)
         logger.error(
             f"Failed to retrieve logs for {parts} {name}. Make sure DSS is correctly initialized."  # noqa: E501
         )
         logger.info("Note: You might want to run")
         logger.info("  dss status      to check the current status")
         logger.info("  dss initialize  to install dss")
-        return
+        raise RuntimeError()
 
     if not pods:
+        logger.debug(f"Failed to retrieve logs. No pods found for {parts} {name}.")
         logger.error(f"Failed to retrieve logs. No pods found for {parts} {name}.")
-        return
+        raise RuntimeError()
 
     for pod in pods:
         # Retrieve logs from the pod
@@ -87,7 +92,10 @@ def get_logs(parts: str, name: str, lightkube_client: Client) -> None:
                 line = line.rstrip("\n")
                 logger.info(line)
         except ApiError as e:
-            logger.error(e)
+            logger.debug(
+                f"Failed to retrieve logs for pod {pod.metadata.name}: {e}", exc_info=True
+            )
             logger.error(
                 f"Failed to retrieve logs. There was a problem while getting the logs for {pod.metadata.name}"  # noqa: E501
             )
+            raise RuntimeError()

--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -222,13 +222,17 @@ def remove_notebook_command(name: str, kubeconfig: str):
     """
     logger.info("Executing remove command")
 
-    kubeconfig = get_default_kubeconfig(kubeconfig)
-    lightkube_client = get_lightkube_client(kubeconfig)
-
     try:
+        kubeconfig = get_default_kubeconfig(kubeconfig)
+        lightkube_client = get_lightkube_client(kubeconfig)
+
         remove_notebook(name=name, lightkube_client=lightkube_client)
     except RuntimeError:
-        exit(1)
+        click.get_current_context().exit(1)
+    except Exception as e:
+        logger.debug(f"Failed to remove notebook: {e}.", exc_info=True)
+        logger.error(f"Failed to remove notebook: {str(e)}.")
+        click.get_current_context().exit(1)
 
 
 @main.command(name="purge")

--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -71,10 +71,17 @@ def create_notebook_command(name: str, image: str, kubeconfig: str) -> None:
             " For more information on using a specific image, see dss create --help."
         )
 
-    kubeconfig = get_default_kubeconfig(kubeconfig)
-    lightkube_client = get_lightkube_client(kubeconfig)
+    try:
+        kubeconfig = get_default_kubeconfig(kubeconfig)
+        lightkube_client = get_lightkube_client(kubeconfig)
 
-    create_notebook(name=name, image=image, lightkube_client=lightkube_client)
+        create_notebook(name=name, image=image, lightkube_client=lightkube_client)
+    except RuntimeError:
+        click.get_current_context().exit(1)
+    except Exception as e:
+        logger.debug(f"Failed to create notebook {name}: {e}.", exc_info=True)
+        logger.error(f"Failed to create notebook {name}: {str(e)}.")
+        click.get_current_context().exit(1)
 
 
 create_notebook_command.help += f"""

--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -38,6 +38,8 @@ def initialize_command(kubeconfig: str) -> None:
         lightkube_client = get_lightkube_client(kubeconfig)
 
         initialize(lightkube_client=lightkube_client)
+    except RuntimeError:
+        click.get_current_context().exit(1)
     except Exception as e:
         logger.debug(f"Failed to initialize dss: {e}.", exc_info=True)
         logger.error(f"Failed to initialize dss: {str(e)}.")

--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -155,6 +155,10 @@ def status_command(kubeconfig: str) -> None:
         get_status(lightkube_client)
     except RuntimeError:
         click.get_current_context().exit(1)
+    except Exception as e:
+        logger.debug(f"Failed to retrieve status: {e}.", exc_info=True)
+        logger.error(f"Failed to retrieve status: {str(e)}.")
+        click.get_current_context().exit(1)
 
 
 @main.command(name="list")

--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -118,15 +118,22 @@ def logs_command(kubeconfig: str, notebook_name: str, print_all: bool, mlflow: b
         )
         return
 
-    kubeconfig = get_default_kubeconfig(kubeconfig)
-    lightkube_client = get_lightkube_client(kubeconfig)
+    try:
+        kubeconfig = get_default_kubeconfig(kubeconfig)
+        lightkube_client = get_lightkube_client(kubeconfig)
 
-    if print_all:
-        get_logs("all", None, lightkube_client)
-    elif mlflow:
-        get_logs("mlflow", None, lightkube_client)
-    elif notebook_name:
-        get_logs("notebooks", notebook_name, lightkube_client)
+        if print_all:
+            get_logs("all", None, lightkube_client)
+        elif mlflow:
+            get_logs("mlflow", None, lightkube_client)
+        elif notebook_name:
+            get_logs("notebooks", notebook_name, lightkube_client)
+    except RuntimeError:
+        click.get_current_context().exit(1)
+    except Exception as e:
+        logger.debug(f"Failed to retrieve logs: {e}.", exc_info=True)
+        logger.error(f"Failed to retrieve logs: {str(e)}.")
+        click.get_current_context().exit(1)
 
 
 @main.command(name="status")

--- a/src/dss/main.py
+++ b/src/dss/main.py
@@ -32,10 +32,15 @@ def initialize_command(kubeconfig: str) -> None:
     """
     logger.info("Executing initialize command")
 
-    kubeconfig = get_default_kubeconfig(kubeconfig)
-    lightkube_client = get_lightkube_client(kubeconfig)
+    try:
+        kubeconfig = get_default_kubeconfig(kubeconfig)
+        lightkube_client = get_lightkube_client(kubeconfig)
 
-    initialize(lightkube_client=lightkube_client)
+        initialize(lightkube_client=lightkube_client)
+    except Exception as e:
+        logger.debug(f"Failed to initialize dss: {e}.", exc_info=True)
+        logger.error(f"Failed to initialize dss: {str(e)}.")
+        click.get_current_context().exit(1)
 
 
 IMAGE_OPTION_HELP = "\b\nThe image used for the notebook server.\n"

--- a/src/dss/remove_notebook.py
+++ b/src/dss/remove_notebook.py
@@ -25,10 +25,10 @@ def remove_notebook(name: str, lightkube_client: Client) -> None:
     if not does_notebook_exist(
         name=name, namespace=DSS_NAMESPACE, lightkube_client=lightkube_client
     ):
-        logger.error(
-            f"Failed to remove Notebook. Notebook {name} does not exist. Run 'dss list' to check all notebooks."  # noqa E501
-        )
-        raise RuntimeError("Failed to remove Notebook not found.")
+        logger.debug(f"Failed to remove Notebook. Notebook {name} does not exist.")
+        logger.error(f"Failed to remove Notebook. Notebook {name} does not exist.")  # noqa E501
+        logger.info("Run 'dss list' to check all notebooks.")
+        raise RuntimeError()
 
     # From this point forward we know either one or both
     # resources (Deployment, Service) exist for the Notebook.
@@ -49,11 +49,12 @@ def remove_notebook(name: str, lightkube_client: Client) -> None:
                 exceptions.append(err)
 
     if exceptions:
+        logger.debug(f"Failed to remove notebook {name}: {exceptions}")
         logger.error(f"Failed to remove notebook {name}. Please try again.")
         logger.info("Note: You might want to run")
         logger.info("  dss status      to check the current status")
         logger.info(f"  dss logs {name} to review the notebook logs")
-        raise RuntimeError(f"Failed to remove notebook {name} with errors", exceptions)
+        raise RuntimeError()
     else:
         logger.info(
             f"Removing the notebook {name}. Check `dss list` for the status of the notebook."

--- a/src/dss/status.py
+++ b/src/dss/status.py
@@ -15,35 +15,35 @@ def get_status(lightkube_client: Client) -> None:
     Args:
         lightkube_client (Client): The Kubernetes client.
     """
+    # Check MLflow deployment
+    mlflow_ready = does_mlflow_deployment_exist(lightkube_client)
+
+    # Log MLflow deployment status and URL
+    if mlflow_ready:
+        mlflow_url = get_service_url(MLFLOW_DEPLOYMENT_NAME, DSS_NAMESPACE, lightkube_client)
+        logger.info("MLflow deployment: Ready")
+        logger.info(f"MLflow URL: {mlflow_url}")
+    else:
+        logger.info("MLflow deployment: Not ready")
+
+    # Check NVIDIA GPU acceleration
+    gpu_acceleration = False
     try:
-        # Check MLflow deployment
-        mlflow_ready = does_mlflow_deployment_exist(lightkube_client)
-
-        # Log MLflow deployment status and URL
-        if mlflow_ready:
-            mlflow_url = get_service_url(MLFLOW_DEPLOYMENT_NAME, DSS_NAMESPACE, lightkube_client)
-            logger.info("MLflow deployment: Ready")
-            logger.info(f"MLflow URL: {mlflow_url}")
-        else:
-            logger.info("MLflow deployment: Not ready")
-
-        # Check NVIDIA GPU acceleration
-        gpu_acceleration = False
         node_labels = get_labels_for_node(lightkube_client)
-        if (
-            "nvidia.com/gpu.present" in node_labels
-            and "nvidia.com/gpu.deploy.container-toolkit" in node_labels
-            and "nvidia.com/gpu.deploy.device-plugin" in node_labels
-        ):
-            gpu_acceleration = True
-            card_name = node_labels.get("nvidia.com/gpu.product", "NVIDIA GPU")
-
-        # Log GPU status
-        if gpu_acceleration:
-            logger.info(f"GPU acceleration: Enabled ({card_name})")
-        else:
-            logger.info("GPU acceleration: Disabled")
-    except Exception as e:
-        logger.debug(f"Failed to retrieve status: {e}", exc_info=True)
-        logger.error(f"Failed to retrieve status: {e}")
+    except ValueError as e:
+        logger.debug(f"Failed to get labels for nodes: {e}.", exc_info=True)
+        logger.error(f"Failed to retrieve status: {e}.")
         raise RuntimeError()
+    if (
+        "nvidia.com/gpu.present" in node_labels
+        and "nvidia.com/gpu.deploy.container-toolkit" in node_labels
+        and "nvidia.com/gpu.deploy.device-plugin" in node_labels
+    ):
+        gpu_acceleration = True
+        card_name = node_labels.get("nvidia.com/gpu.product", "NVIDIA GPU")
+
+    # Log GPU status
+    if gpu_acceleration:
+        logger.info(f"GPU acceleration: Enabled ({card_name})")
+    else:
+        logger.info("GPU acceleration: Disabled")

--- a/src/dss/status.py
+++ b/src/dss/status.py
@@ -44,5 +44,6 @@ def get_status(lightkube_client: Client) -> None:
         else:
             logger.info("GPU acceleration: Disabled")
     except Exception as e:
+        logger.debug(f"Failed to retrieve status: {e}", exc_info=True)
         logger.error(f"Failed to retrieve status: {e}")
-        return
+        raise RuntimeError()

--- a/src/dss/stop.py
+++ b/src/dss/stop.py
@@ -24,9 +24,10 @@ def stop_notebook(name: str, lightkube_client: Client) -> None:
     if not does_notebook_exist(
         name=name, namespace=DSS_NAMESPACE, lightkube_client=lightkube_client
     ):
+        logger.debug(f"Failed to stop Notebook. Notebook {name} does not exist.")
         logger.error(f"Failed to stop Notebook. Notebook {name} does not exist.")
         logger.info("Run 'dss list' to check all notebooks.")
-        raise RuntimeError(f"Failed to stop Notebook. Notebook {name} does not exist.")
+        raise RuntimeError()
 
     obj = Deployment.Scale(
         metadata=ObjectMeta(name=name, namespace=DSS_NAMESPACE), spec=ScaleSpec(replicas=0)
@@ -39,6 +40,6 @@ def stop_notebook(name: str, lightkube_client: Client) -> None:
         )
         return
     except ApiError as e:
-        logger.error(f"Failed to stop Notebook {name}")
-        logger.debug(f"Failed to scale down Deployment {name} with error: {e}")
-        raise e
+        logger.debug(f"Failed to scale down Deployment {name}: {e}", exc_info=True)
+        logger.error(f"Failed to stop notebook {name}.")
+        raise RuntimeError()

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from lightkube import ApiError
 
+from dss.config import DSS_NAMESPACE
 from dss.logs import get_logs
 
 
@@ -48,17 +49,22 @@ def test_get_logs_failure_notebook_not_exist(
     """
     Test case to verify behavior when the specified notebook does not exist.
     """
+    notebook_name = "test_notebook"
 
     # Mock the behavior of Client
     mock_client_instance = MagicMock()
     mock_client_instance.get.return_value = None
 
-    # Call the function to test
-    get_logs("notebooks", "non_existent_notebook", mock_client_instance)
+    with pytest.raises(RuntimeError):
+        # Call the function to test
+        get_logs("notebooks", notebook_name, mock_client_instance)
 
     # Assertions
+    mock_logger.debug.assert_called_with(
+        f"Failed to retrieve logs. Deployment '{notebook_name}' does not exist in {DSS_NAMESPACE} namespace."  # noqa E501
+    )
     mock_logger.error.assert_called_with(
-        "Failed to retrieve logs. Notebook 'non_existent_notebook' does not exist."
+        f"Failed to retrieve logs. Notebook '{notebook_name}' does not exist."
     )
     mock_logger.info.assert_called_with("Run 'dss list' to check all notebooks.")
 
@@ -77,11 +83,13 @@ def test_get_logs_failure_retrieve_mlflow(mock_client: MagicMock, mock_logger: M
     mock_client.return_value = mock_client_instance
 
     # Call the function to test
-    get_logs("mlflow", None, mock_client_instance)
+    with pytest.raises(RuntimeError):
+        get_logs("mlflow", None, mock_client_instance)
 
     # Assertions
+    mock_logger.debug.assert_called_with(f"Failed to retrieve logs for MLflow: {api_error}")
     mock_logger.error.assert_called_with(
-        "Failed to retrieve logs. MLflow seems to be not present.Make sure DSS is correctly initialized."  # noqa: E501
+        "Failed to retrieve logs. MLflow seems to be not present. Make sure DSS is correctly initialized."  # noqa: E501
     )
     mock_logger.info.assert_any_call("Note: You might want to run")
     mock_logger.info.assert_any_call("  dss status      to check the current status")
@@ -95,6 +103,7 @@ def test_get_logs_failure_retrieve_pod(
     """
     Test case to verify behavior when retrieval of pods fails.
     """
+    notebook_name = "test_notebook"
 
     # Mock the behavior of Client and Deployment
     mock_client_instance = MagicMock()
@@ -104,12 +113,17 @@ def test_get_logs_failure_retrieve_pod(
     mock_client_instance.get.return_value = mock_deployment_instance
 
     # Mock the behavior of Pod with an ApiError
-    mock_client_instance.list.side_effect = ApiError(response=MagicMock())
+    api_error = ApiError(response=MagicMock())
+    mock_client_instance.list.side_effect = api_error
 
-    # Call the function to test
-    get_logs("notebooks", "test_notebook", mock_client_instance)
+    with pytest.raises(RuntimeError):
+        # Call the function to test
+        get_logs("notebooks", notebook_name, mock_client_instance)
 
     # Assertions
+    mock_logger.debug.assert_called_with(
+        f"Failed to retrieve logs for notebooks {notebook_name}: {api_error}", exc_info=True
+    )
     mock_logger.error.assert_called_with(
         "Failed to retrieve logs for notebooks test_notebook. Make sure DSS is correctly initialized."  # noqa: E501
     )
@@ -255,16 +269,24 @@ def test_get_logs_failure_retrieve_pod_logs(
 
     # Mock the behavior of Pod
     mock_pod_instance = MagicMock()
-    mock_pod_instance.metadata.name = "test_pod"
+    pod_name = "test_pod"
+    mock_pod_instance.metadata.name = pod_name
 
     # Set the return values for list method calls
     mock_client_instance.list.side_effect = [[mock_deployment_instance], [mock_pod_instance]]
 
     # Mock the log method of Client to raise an exception
-    mock_client_instance.log.side_effect = ApiError("Test error", response=MagicMock())
+    api_error = ApiError("Test error", response=MagicMock())
+    mock_client_instance.log.side_effect = api_error
 
     # Call the function to test
-    get_logs("notebooks", "test_notebook", mock_client_instance)
+    with pytest.raises(RuntimeError):
+        get_logs("notebooks", "test_notebook", mock_client_instance)
+
+    # Assertions
+    mock_logger.debug.assert_called_with(
+        f"Failed to retrieve logs for pod {pod_name}: {api_error}", exc_info=True
+    )
     mock_logger.error.assert_any_call(
-        "Failed to retrieve logs. There was a problem while getting the logs for test_pod"
+        f"Failed to retrieve logs. There was a problem while getting the logs for {pod_name}"
     )

--- a/tests/unit/test_logs.py
+++ b/tests/unit/test_logs.py
@@ -87,7 +87,9 @@ def test_get_logs_failure_retrieve_mlflow(mock_client: MagicMock, mock_logger: M
         get_logs("mlflow", None, mock_client_instance)
 
     # Assertions
-    mock_logger.debug.assert_called_with(f"Failed to retrieve logs for MLflow: {api_error}")
+    mock_logger.debug.assert_called_with(
+        f"Failed to retrieve logs for MLflow: {api_error}", exc_info=True
+    )
     mock_logger.error.assert_called_with(
         "Failed to retrieve logs. MLflow seems to be not present. Make sure DSS is correctly initialized."  # noqa: E501
     )

--- a/tests/unit/test_remove_notebook.py
+++ b/tests/unit/test_remove_notebook.py
@@ -62,13 +62,17 @@ def test_remove_notebook_not_found(
 
     mock_does_notebook_exist.return_value = False
 
-    with pytest.raises(RuntimeError) as exc_info:
+    with pytest.raises(RuntimeError):
         remove_notebook(notebook_name, mock_client)
 
-    assert str(exc_info.value) == "Failed to remove Notebook not found."
-    mock_logger.error.assert_called_once_with(
-        f"Failed to remove Notebook. Notebook {notebook_name} does not exist. Run 'dss list' to check all notebooks."  # noqa E501
+    # Assertions
+    mock_logger.debug.assert_called_once_with(
+        f"Failed to remove Notebook. Notebook {notebook_name} does not exist."
     )
+    mock_logger.error.assert_called_once_with(
+        f"Failed to remove Notebook. Notebook {notebook_name} does not exist."
+    )
+    mock_logger.info.assert_called_once_with("Run 'dss list' to check all notebooks.")
 
 
 @pytest.mark.parametrize(
@@ -104,11 +108,11 @@ def test_remove_notebook_one_resource_not_exist(
     "lightkube_client_side_effects, debug_log_calls",
     [
         # Removing the Deployment error
-        ([FakeApiError(400), None], 1),
+        ([FakeApiError(400), None], 2),
         # Removing the Service error
-        ([None, FakeApiError(400)], 1),
+        ([None, FakeApiError(400)], 2),
         # Removing both the Deployment and Service error
-        ([FakeApiError(400), FakeApiError(400)], 2),
+        ([FakeApiError(400), FakeApiError(400)], 3),
     ],
 )
 def test_remove_notebook_unexpected_error(

--- a/tests/unit/test_stop.py
+++ b/tests/unit/test_stop.py
@@ -67,6 +67,9 @@ def test_stop_notebook_not_found(
         stop_notebook(name=notebook_name, lightkube_client=mock_client)
 
     # Assert
+    mock_logger.debug.assert_called_with(
+        f"Failed to stop Notebook. Notebook {notebook_name} does not exist."
+    )
     mock_logger.error.assert_called_with(
         f"Failed to stop Notebook. Notebook {notebook_name} does not exist."
     )
@@ -86,9 +89,11 @@ def test_stop_notebook_unexpected_error(
     mock_client.replace.side_effect = mock_error
 
     # Call the function to test
-    with pytest.raises(FakeApiError):
+    with pytest.raises(RuntimeError):
         stop_notebook(name=notebook_name, lightkube_client=mock_client)
 
     # Assert
-    mock_logger.error.assert_called_with(f"Failed to stop Notebook {notebook_name}")
-    mock_logger.debug(f"Failed to scale down Deployment {notebook_name} with error: {mock_error}")
+    mock_logger.debug.assert_called_with(
+        f"Failed to scale down Deployment {notebook_name}: {mock_error}", exc_info=True
+    )
+    mock_logger.error.assert_called_with(f"Failed to stop notebook {notebook_name}.")


### PR DESCRIPTION
closes #78 

**Note: Integration tests in the CI are failing due to https://github.com/microsoft/linux-package-repositories/issues/130, but they can be run locally with `tox -e integration`**

## Summary
Refactors the following `dss` commands:
* `create`
* `initialize`
* `logs`
* `remove`
* `status`
* `stop`

With the following changes:
1. use `logger.debug` to store the error with traceback
2. exit with `1` exit code in failure cases
3. raise `RuntimeError` in failure cases inside the module function
4. handle `RuntimeError` in main without logging anything else, just by exiting with status code 1 (logging was done in the module function)
5. handle any other `Exception` in main by providing descriptive error message and use debug to store error and traceback and exit with status code 1.

## Notice on `dss initialize`
This PR refactors `initialize` command in main to catch `RuntimeError` even tho it is not currently raised in the `initialize.py` module. This is because we expect to raise this type of error once we refactor the command, refactoring is being tracked in #68.