### PR TITLE
Change snap name to `data-science-stack`

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,10 +1,10 @@
-name: dss
+name: data-science-stack
 summary: ML development and experimentation environment manager
 description: |
      The DSS is a tool that allows workstations users to deploy
      and manage development and experimentation environments
      in systems with GPU support.
-adopt-info: dss
+adopt-info: data-science-stack
 base: core22
 confinement: strict
 architectures:
@@ -16,13 +16,13 @@ plugs:
     read:
       - $HOME/.dss/config
 apps:
-  dss:
+  data-science-stack:
     command: bin/dss
     plugs:
       - home
       - network
 parts:
-  dss:
+  data-science-stack:
     plugin: python
     source: .
     override-pull: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -16,7 +16,7 @@ plugs:
     read:
       - $HOME/.dss/config
 apps:
-  data-science-stack:
+  dss:
     command: bin/dss
     plugs:
       - home


### PR DESCRIPTION
Change the snap name to `data-science-stack`.

For local testing don't forget to create the alias.

```
snapcraft
snap install data-science-stack_<name>.snap --dangerous
sudo snap alias  data-science-stack.dss dss
dss --help
```