### PR TITLE
docs: Remove warnings by fixing title underline

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 .. _home:
 
 Data Science Stack
-============
+==================
 
 Data science stack (DSS) is a ready-to-run environment for machine learning
 and data science.  It’s built on open-source tooling (including MicroK8s,


### PR DESCRIPTION
The build in readthedocs is failing with the following message

https://readthedocs.com/projects/canonical-data-science-stack/builds/2173740/
```
Running Sphinx v7.3.7
matplotlib is not installed, social cards will not be generated
making output directory... done
myst v3.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'substitution', 'deflist', 'linkify'}, disable_syntax=[], all_links_external=False, links_external_new_tab=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=0, heading_slug_func=None, html_meta={}, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
building [mo]: targets for 0 po files that are out of date
writing output... 
building [dirhtml]: targets for 6 source files that are out of date
updating environment: [new config] 6 added, 0 changed, 0 removed
reading sources... [ 17%] explanation/index
reading sources... [ 33%] how-to/index
reading sources... [ 50%] index
reading sources... [ 67%] reference/index
reading sources... [ 83%] tutorial/index
reading sources... [100%] tutorial/installation

/home/docs/checkouts/readthedocs.org/user_builds/canonical-data-science-stack/checkouts/latest/docs/index.rst:5: WARNING: Title underline too short.

Data Science Stack
============
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [ 17%] explanation/index
writing output... [ 33%] how-to/index
writing output... [ 50%] index
writing output... [ 67%] reference/index
writing output... [ 83%] tutorial/index
writing output... [100%] tutorial/installation

generating indices... genindex done
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
Updating searchtools for Read the Docs search... build finished with problems, 1 warning.
```

The above should be because 
1. the title's underline is less than the text
2. in local mode the build succeeds even with the warnings