### PR TITLE
Intel PoC README: add caveat for multi-gpu systems

### DIFF
--- a/poc/intel/README.md
+++ b/poc/intel/README.md
@@ -3,11 +3,11 @@
 Launch Jupyter notebooks with Intel xGPU support enabled for Tensorflow
 PyTorch, and OpenVINO. Note that MLFlow is also deployed along side Jupyter.
 
-## Verify Intel xGPU Availablity
+## Verify Intel xGPU Availability
 
-Running this PoC requires an Intel discreet or integrated GPU to be available
+Running this PoC requires an Intel discrete or integrated GPU to be available
 on your system in order to run. In cases where a system contains both a dGPU
-and iGPU (e.g. NVIDIA discreet card with Intel iGPU), it is important to
+and iGPU (e.g. NVIDIA discrete card with Intel iGPU), it is important to
 verify that the Intel xGPU is visible to the OS. This can be done with a
 command like:
 

--- a/poc/intel/README.md
+++ b/poc/intel/README.md
@@ -1,17 +1,31 @@
 # Intel xGPU PoC
 
-Launch Jupyter notebooks with Intel xGPU support enabled for Tensorflow, PyTorch, and OpenVINO.
-Note that MLFlow is also deployed along side Jupyter.
+Launch Jupyter notebooks with Intel xGPU support enabled for Tensorflow
+PyTorch, and OpenVINO. Note that MLFlow is also deployed along side Jupyter.
+
+## Verify Intel xGPU Availablity
+
+Running this PoC requires an Intel discreet or integrated GPU to be available
+on your system in order to run. In cases where a system contains both a dGPU
+and iGPU (e.g. NVIDIA discreet card with Intel iGPU), it is important to
+verify that the Intel xGPU is visible to the OS. This can be done with a
+command like:
+
+```
+$ lspci -nn | grep  -Ei 'VGA|DISPLAY'
+```
 
 ## Application Details
 
 Below are important notes about each application. 
 
-* **itex (Tensorflow)**: pulls image directly from DockerHub; requires 8 GiB RAM. 
+* **itex (Tensorflow)**: pulls image directly from DockerHub; requires 8 GiB RAM.
 * **ipex (PyTorch)**: pulls image directly from DockerHub; requires 16 GiB RAM.
-* **OpenVINO**: requires a user to first build the Docker image locally (see shell script in `openvino-image` folder), so Docker must be installed and configured on the system; requires 8 GiB RAM.
+* **OpenVINO**: requires a user to first build the Docker image locally (see
+shell script in `openvino-image` folder), so Docker must be installed and
+configured on the system; requires 8 GiB RAM.
 
 ## Limitations
 
-This PoC assumes a single Intel xGPU on the system where it is run, so a user cannot launch
-multiple applications simultaneously.
+This PoC assumes a single Intel xGPU on the system where it is run, so a user
+cannot launch multiple applications simultaneously.


### PR DESCRIPTION
This adds a section to the Intel PoC README as a follow up to some troubleshooting work performed on systems containing both a NVIDIA dGPU + Intel CPU+iGPU.