### PR TITLE
docs: Fix the list

### DIFF
--- a/docs/how-to/jupyter-notebook/notebook-logs.rst
+++ b/docs/how-to/jupyter-notebook/notebook-logs.rst
@@ -48,6 +48,7 @@ Retrieving Notebook Logs
        [INFO] 2024-04-30T10:09:13.034Z [jupyter] [W 2024-04-30 10:09:13.033 ServerApp] A `_jupyter_server_extension_points` function was not found in nbclassic. Instead, a `_jupyter_server_extension_paths` function was found and will be used for now. This function name will be deprecated in future releases of Jupyter Server.
        [INFO] 2024-04-30T10:09:13.036Z [jupyter] [I 2024-04-30 10:09:13.036 ServerApp] jupyter_server_fileid | extension was successfully linked.
        [INFO] 2024-04-30T10:09:13.038Z [jupyter] [I 2024-04-30 10:09:13.038 ServerApp] jupyter_server_mathjax | extension was successfully linked.
+
 Conclusion
 ----------
 


### PR DESCRIPTION
We saw the docs failing in https://github.com/canonical/data-science-stack/pull/112 because of the following error

```
/home/docs/checkouts/readthedocs.org/user_builds/canonical-data-science-stack/checkouts/latest/docs/how-to/jupyter-notebook/notebook-logs.rst:51: WARNING: Enumerated list ends without a blank line; unexpected unindent.
```

This was because of https://github.com/canonical/data-science-stack/pull/109

It looks like ReadTheDocs sometimes failed to build, even though the existing CI was passing. I've extended now the CI to also build with readthedocs so we can capture such errors in the future
https://library.canonical.com/documentation/publish-on-read-the-docs#enable-pr-previews-7