### PR TITLE
docs: Use proper microk8s config command

### DIFF
--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -90,7 +90,7 @@ You can initialise the DSS with the following commands:
 
 .. code-block:: bash
 
-   dss initialize --kubeconfig="$(microk8s kubeconfig)"
+   dss initialize --kubeconfig="$(microk8s config)"
 
 Launch a Notebook
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently the instructions have a typo. The command for the kubeconfig should be
```
dss initialize --kubeconfig="$(microk8s config)"
```