### PR TITLE
docs: Use sudo in MicroK8s commands

### DIFF
--- a/docs/how-to/dss/initialize-dss.rst
+++ b/docs/how-to/dss/initialize-dss.rst
@@ -27,7 +27,7 @@ Initialize DSS through the `dss initialize` command, for example:
 
 .. code-block:: shell
 
-    dss initialize --kubeconfig "$(microk8s config)"
+    dss initialize --kubeconfig "$(sudo microk8s config)"
 
 where we provide the content of our MicroK8s cluster's kubeconfig using the `--kubeconfig` option.
 

--- a/docs/reference/enable-gpu.rst
+++ b/docs/reference/enable-gpu.rst
@@ -16,7 +16,7 @@ Before installing DSS:
 
    .. code-block:: bash
 
-     microk8s enable gpu
+     sudo microk8s enable gpu
 
 3. Wait for GPU operator components to be ready. This can take around 5 minutes.
 
@@ -35,12 +35,12 @@ Before installing DSS:
      dss status
 
    Expected output:
-    
+
    .. code-block:: bash
 
      [INFO] MLflow deployment: Not ready
      [INFO] GPU acceleration: Enabled (NVIDIA-GeForce-RTX-3070-Ti)
 
    .. note::
-        
+
      the GPU model `NVIDIA-GeForce-RTX-3070-Ti` will be different depending on your device.

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -31,7 +31,7 @@ You can install MicroK8s with the following commands:
 .. code-block:: bash
 
    sudo snap install microk8s --channel 1.28/stable --classic
-   microk8s enable storage dns rbac
+   sudo microk8s enable storage dns rbac
 
 For further information on how to get started with MicroK8s, you can
 follow `MicroK8s' Getting Started`_ page.
@@ -54,7 +54,7 @@ command:
 
 .. code-block:: bash
 
-   microk8s enable gpu
+   sudo microk8s enable gpu
 
 
 .. note::
@@ -90,7 +90,7 @@ You can initialise the DSS with the following commands:
 
 .. code-block:: bash
 
-   dss initialize --kubeconfig="$(microk8s config)"
+   dss initialize --kubeconfig="$(sudo microk8s config)"
 
 Launch a Notebook
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Right now the docs are not using `sudo` for the MicroK8s commands, neither inform users to set the groups for using the `microk8s` commands without sudo
https://microk8s.io/docs/getting-started

The above will result in errors in both
1. Initialising the MicroK8s addons (dns, gpu)
2. The DSS CLI won't be able to connect to microK8s

The PR adds `sudo` to the commands, since this is also the long term approach the K8s team will take for the new K8s cli as well.