### PR TITLE
docs: Refactor create-notebook page for GPU link

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -32,3 +32,5 @@ snapcraft
 Snapcraft
 toolkits
 hostpath
+nvidia
+gpu

--- a/docs/how-to/jupyter-notebook/create-notebook.rst
+++ b/docs/how-to/jupyter-notebook/create-notebook.rst
@@ -16,42 +16,52 @@ Before creating a notebook, ensure you have the following:
 - DSS CLI installed on your workstation
 - DSS initialized
 
-Creating a Notebook
+Select an Image
+---------------
+
+Before creating a notebook, you need to select an image that includes the packages and toolkits you need.
+To see a list of recommended images and their aliases, see:
+
+.. code-block:: bash
+
+    dss create --help
+
+The help text includes a list of recommended images and aliases so you don't need to type the full image name.
+For this guide, we will use the image `kubeflownotebookswg/jupyter-scipy:v1.8.0`
+
+Launch the Notebook
 -------------------
 
-1. **Select an image**:
+Create a new notebook using ``dss create``:
 
-    Before creating a notebook, you need to select an image that includes the packages and toolkits you need.  To see a list of recommended images and their aliases, see:
+.. code-block:: bash
 
-    .. code-block:: bash
+    dss create my-notebook --image kubeflownotebookswg/jupyter-scipy:v1.8.0
 
-        dss create --help
+This will pull the notebook image and start a Notebook server, printing the URL of the notebook once complete.  Expected output:
 
-    The help text includes a list of recommended images and aliases so you don't need to type the full image name.  For this guide, we will use the image `kubeflownotebookswg/jupyter-scipy:v1.8.0`
+.. code-block:: none
 
-2. **Create the notebook**:
+    [INFO] Executing create command
+    [INFO] Waiting for deployment test-notebook in namespace dss to be ready...
+    [INFO] Deployment test-notebook in namespace dss is ready
+    [INFO] Success: Notebook test-notebook created successfully.
+    [INFO] Access the notebook at http://10.152.183.42:80.
 
-    Create a new notebook using ``dss create``:
+Access the notebook
+-------------------
 
-    .. code-block:: bash
-
-        dss create my-notebook --image kubeflownotebookswg/jupyter-scipy:v1.8.0
-
-    This will pull the notebook image and start a Notebook server, printing the URL of the notebook once complete.  Expected output:
-
-    .. code-block:: none
-
-        [INFO] Executing create command
-        [INFO] Waiting for deployment test-notebook in namespace dss to be ready...
-        [INFO] Deployment test-notebook in namespace dss is ready
-        [INFO] Success: Notebook test-notebook created successfully.
-        [INFO] Access the notebook at http://10.152.183.42:80.
-
-3. **Access the notebook**:
-
-    To :doc:`access the Notebook </how-to/jupyter-notebook/access-ui>`, use the URL provided in the output.
+To :doc:`access the Notebook </how-to/jupyter-notebook/access-ui>`, use the URL provided in the output.
 
 Conclusion
 ----------
 
 Notebooks are a powerful tool for data scientists and analysts to explore, visualise, and analyse data.  By creating a notebook in the DSS environment, you can leverage the power of the Data Science Stack to run your analyses.
+
+Next Steps
+^^^^^^^^^^
+
+* Want to leverage your NVIDIA GPU? Try :ref:`nvidia-gpu`
+* Want to learn how to interact with your Notebooks? Try :ref:`jupyter-notebooks`
+* Want to learn more about handling data? See :ref:`access-data`
+* Want to connect to MLflow? See :ref:`notebook-mlflow`


### PR DESCRIPTION
This PR revamps the page for creating notebooks by:
1. Adding sections for the different steps, instead of having lists
2. Adding a `Next Steps` section, to redirect users to relevant content

This PR should be merged after https://github.com/canonical/data-science-stack/pull/131, which adds a `ref` link to the NVIDIA GPU page.

cc @afgambin 