### PR TITLE
docs: `s/storage/hostpath-storage` in tutorial for MicroK8s

### DIFF
--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -35,7 +35,9 @@ You can install MicroK8s using ``snap`` as follows:
 .. code-block:: bash
 
    sudo snap install microk8s --channel 1.28/stable --classic
-   sudo microk8s enable hostpath-storage dns rbac
+   sudo microk8s enable hostpath-storage
+   sudo microk8s enable dns
+   sudo microk8s enable rbac
 
 .. _install_DSS_CLI:
 

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -35,7 +35,7 @@ You can install MicroK8s using ``snap`` as follows:
 .. code-block:: bash
 
    sudo snap install microk8s --channel 1.28/stable --classic
-   sudo microk8s enable storage dns rbac
+   sudo microk8s enable hostpath-storage dns rbac
 
 .. _install_DSS_CLI:
 


### PR DESCRIPTION
The `storage` addon is deprecated and will be removed, prefer `hostpath-storage`.

When following the tutorial, the logs show:

```
ubuntu@dev:~$ sudo snap install microk8s --channel 1.28/stable --classic
sudo microk8s enable storage dns rbac
microk8s (1.28/stable) v1.28.12 from Canonical✓ installed
Infer repository core for addon storage
Infer repository core for addon dns
Infer repository core for addon rbac
WARNING: Do not enable or disable multiple addons in one command.
         This form of chained operations on addons will be DEPRECATED in the future.
         Please, enable one addon at a time: 'microk8s enable <addon>'
DEPRECATION WARNING: 'storage' is deprecated and will soon be removed. Please use 'hostpath-storage' instead.

Infer repository core for addon hostpath-storage
Enabling default storage class.
WARNING: Hostpath storage is not suitable for production environments.
         A hostpath volume can grow beyond the size limit set in the volume claim manifest.

deployment.apps/hostpath-provisioner created
```