### PR TITLE
Update `dss status` to show intel GPU status

### DIFF
--- a/src/dss/status.py
+++ b/src/dss/status.py
@@ -50,13 +50,8 @@ def get_status(lightkube_client: Client) -> None:
     else:
         logger.info("NVIDIA GPU acceleration: Disabled")
 
-    # Check Intel GPU acceleration
-    intel_gpu_acceleration = False
+    # Check Intel GPU acceleration and Log status
     if "intel.feature.node.kubernetes.io/gpu" in node_labels:
-        intel_gpu_acceleration = True
-
-    # Log Intel GPU status
-    if intel_gpu_acceleration:
         logger.info("Intel GPU acceleration: Enabled")
     else:
         logger.info("Intel GPU acceleration: Disabled")

--- a/src/dss/utils.py
+++ b/src/dss/utils.py
@@ -286,6 +286,23 @@ def does_mlflow_deployment_exist(lightkube_client: Client) -> bool:
             raise e
 
 
+def intel_is_present_in_node(lightkube_client: Client) -> bool:
+    """Return True if the Node has the intel GPU label, False otherwise.
+
+    Args:
+        lightkube_client (Client): The Kubernetes client.
+    """
+    try:
+        node_labels = get_labels_for_node(lightkube_client)
+    except ValueError as e:
+        logger.debug(f"Failed to get labels for nodes: {e}.", exc_info=True)
+        logger.error(f"Failed to retrieve status: {e}.")
+        raise RuntimeError()
+    if "intel.feature.node.kubernetes.io/gpu" in node_labels:
+        return True
+    return False
+
+
 def get_labels_for_node(lightkube_client: Client) -> dict:
     """
     Get the labels of the only node in the cluster.

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -22,6 +22,7 @@ from dss.status import get_status
                 "MLflow deployment: Ready",
                 "MLflow URL: <Mocked MLflow URL>",
                 "NVIDIA GPU acceleration: Enabled (Test-GPU)",
+                "Intel GPU acceleration: Disabled",
             ],
         ),
         (

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -21,7 +21,37 @@ from dss.status import get_status
             [
                 "MLflow deployment: Ready",
                 "MLflow URL: <Mocked MLflow URL>",
-                "GPU acceleration: Enabled (Test-GPU)",
+                "NVIDIA GPU acceleration: Enabled (Test-GPU)",
+            ],
+        ),
+        (
+            True,
+            "<Mocked MLflow URL>",
+            {
+                "intel.feature.node.kubernetes.io/gpu": "true",
+            },
+            [
+                "MLflow deployment: Ready",
+                "MLflow URL: <Mocked MLflow URL>",
+                "NVIDIA GPU acceleration: Disabled",
+                "Intel GPU acceleration: Enabled",
+            ],
+        ),
+        (
+            True,
+            "<Mocked MLflow URL>",
+            {
+                "nvidia.com/gpu.present": "true",
+                "nvidia.com/gpu.deploy.container-toolkit": "true",
+                "nvidia.com/gpu.deploy.device-plugin": "true",
+                "nvidia.com/gpu.product": "Test-GPU",
+                "intel.feature.node.kubernetes.io/gpu": "true",
+            },
+            [
+                "MLflow deployment: Ready",
+                "MLflow URL: <Mocked MLflow URL>",
+                "NVIDIA GPU acceleration: Enabled (Test-GPU)",
+                "Intel GPU acceleration: Enabled",
             ],
         ),
         (
@@ -31,10 +61,20 @@ from dss.status import get_status
             [
                 "MLflow deployment: Ready",
                 "MLflow URL: <Mocked MLflow URL>",
-                "GPU acceleration: Disabled",
+                "NVIDIA GPU acceleration: Disabled",
+                "Intel GPU acceleration: Disabled",
             ],
         ),
-        (False, None, {}, ["MLflow deployment: Not ready", "GPU acceleration: Disabled"]),
+        (
+            False,
+            None,
+            {},
+            [
+                "MLflow deployment: Not ready",
+                "NVIDIA GPU acceleration: Disabled",
+                "Intel GPU acceleration: Disabled",
+            ],
+        ),
     ],
 )
 def test_get_status_with_different_scenarios(

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -92,6 +92,7 @@ def test_get_status_with_different_scenarios(
     mocker.patch("dss.status.does_mlflow_deployment_exist", return_value=mlflow_exist)
     mocker.patch("dss.status.get_service_url", return_value=mlflow_url)
     mocker.patch("dss.status.get_labels_for_node", return_value=gpu_labels)
+    mocker.patch("dss.utils.get_labels_for_node", return_value=gpu_labels)
 
     # Mock the logger
     mock_logger = mocker.patch("dss.status.logger")


### PR DESCRIPTION
closes #146

## Summary
* log Intel GPU status in `dss status`
* add unit tests to include Intel GPU status
* refactor NVIDIA part in `dss status` to differentiate between Intel and NVIDIA GPUs