### PR TITLE
feat: update create command to support Intel GPU notebooks

### DIFF
--- a/src/dss/config.py
+++ b/src/dss/config.py
@@ -9,8 +9,10 @@ MANIFEST_TEMPLATES_LOCATION = "./manifest_templates"
 MLFLOW_DEPLOYMENT_NAME = "mlflow"
 NOTEBOOK_PVC_NAME = "notebooks"
 NOTEBOOK_IMAGES_ALIASES = {
+    "intel-pytorch": "intel/intel-extension-for-pytorch:2.1.20-xpu-idp-jupyter",
     "pytorch": "kubeflownotebookswg/jupyter-pytorch-full:v1.8.0",
     "pytorch-cuda": "kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.8.0",
+    "intel-tensorflow": "intel/intel-extension-for-tensorflow:2.15.0-xpu-idp-jupyter",
     "tensorflow": "kubeflownotebookswg/jupyter-tensorflow-full:v1.8.0",
     "tensorflow-cuda": "kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.8.0",
 }

--- a/src/dss/manifest_templates/notebook_deployment.yaml.j2
+++ b/src/dss/manifest_templates/notebook_deployment.yaml.j2
@@ -24,6 +24,21 @@ spec:
           - name: MLFLOW_TRACKING_URI
             value: {{ mlflow_tracking_uri }}
           image: {{ notebook_image }}
+          command:
+            - jupyter
+          args:
+            - lab
+            - --notebook-dir=/home/jovyan
+            - --ip=0.0.0.0
+            - --no-browser
+            - --allow-root
+            - --port=8888
+            - --ServerApp.token=''
+            - --ServerApp.password=''
+            - --ServerApp.allow_origin='*'
+            - --ServerApp.allow_remote_access=True
+            - --ServerApp.authenticate_prometheus=False
+            - --ServerApp.base_url='/'
       {%- if intel_enabled == true %}
           resources:
             limits:

--- a/src/dss/manifest_templates/notebook_deployment.yaml.j2
+++ b/src/dss/manifest_templates/notebook_deployment.yaml.j2
@@ -24,6 +24,11 @@ spec:
           - name: MLFLOW_TRACKING_URI
             value: {{ mlflow_tracking_uri }}
           image: {{ notebook_image }}
+      {%- if intel_enabled == true %}
+          resources:
+            limits:
+              gpu.intel.com/i915: 1
+      {%- endif %}
           imagePullPolicy: IfNotPresent
           name: {{ notebook_name }}
           ports:

--- a/src/dss/utils.py
+++ b/src/dss/utils.py
@@ -286,6 +286,23 @@ def does_mlflow_deployment_exist(lightkube_client: Client) -> bool:
             raise e
 
 
+def intel_is_present_in_node(lightkube_client: Client) -> bool:
+    """Return True if the Node has the intel GPU label, False otherwise.
+
+    Args:
+        lightkube_client (Client): The Kubernetes client.
+    """
+    try:
+        node_labels = get_labels_for_node(lightkube_client)
+    except ValueError as e:
+        logger.debug(f"Failed to get labels for nodes: {e}.", exc_info=True)
+        logger.error(f"Failed to retrieve status: {e}.")
+        raise RuntimeError()
+    if "intel.feature.node.kubernetes.io/gpu" in node_labels:
+        return True
+    return False
+
+
 def get_labels_for_node(lightkube_client: Client) -> dict:
     """
     Get the labels of the only node in the cluster.


### PR DESCRIPTION
This commit introduces an automatic way of scheduling Notebook Servers on Nodes labeled as intel.feature.node.kubernetes.io/gpu.
This commit also affects the command and args that run for the Notebook Servers containers, as these are now part of the requirements for making Intel GPUs work. They should be exactly as [this](https://github.com/canonical/data-science-stack/blob/frenchwr/intel-gpu-integration/src/dss/manifest_templates/notebook_deployment.yaml.j2#L29C1-L43C39).

Fixes #147

### Manual testing

Assuming you have a microk8s cluster with hostpath-storage enabled

1. Clone this repository, checkout to the branch of this PR
2. Build and install from source `pip install .`
3. Initialise `dss initialize --kubeconfig="$(sudo microk8s config)"`
4. Label the node to simulate the Intel plugin has done its job `kubectl label node <name of your node> intel.feature.node.kubernetes.io/gpu=true`
5. Create a notebook `dss create my-notebook --image=ubuntu`
6. Verify the `Deployment` of the server has the resource limits we are interested in:

```
kubectl get deployment -ndss my-notebook -oyaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    ...
    spec:
      containers:
      - env:
        - name: MLFLOW_TRACKING_URI
          value: http://mlflow.dss.svc.cluster.local:5000
        image: kubeflownotebookswg/jupyter-pytorch-full:v1.8.0
        imagePullPolicy: IfNotPresent
        name: my-notebook
        ports:
        - containerPort: 8888
          name: notebook-port
          protocol: TCP
        resources:
          limits:
            gpu.intel.com/i915: "1" # <--- we are interested in this
```

7. Also verify that the `command` and `args` are always set:

```
          command:
            - jupyter
          args:
            - lab
            - --notebook-dir=/home/jovyan
            - --ip=0.0.0.0
            - --no-browser
            - --allow-root
            - --port=8888
            - --ServerApp.token=''
            - --ServerApp.password=''
            - --ServerApp.allow_origin='*'
            - --ServerApp.allow_remote_access=True
            - --ServerApp.authenticate_prometheus=False
            - --ServerApp.base_url='/'
```

Alternatively, you can try the create command w/o labelling the Node. In that case, the `Deployment` should not have any of the resource limits.