### PR TITLE
docs: Add how-to guide to create Intel Notebook 

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -55,4 +55,5 @@ Tensorflow
 toolkits
 Validator
 WSL
+XPU
 yaml

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -4,6 +4,7 @@ DaemonSet
 DS
 DSS
 GeForce
+gpu
 GPUs
 hostpath
 Hostpath
@@ -12,7 +13,10 @@ initialize
 initialized
 initializing
 io
+intel
+IPEX
 ipynb
+ITEX
 Jupyter
 jupyter
 JupyterLab

--- a/docs/how-to/jupyter-notebook.rst
+++ b/docs/how-to/jupyter-notebook.rst
@@ -90,7 +90,7 @@ You can create an Intel GPU-enabled Jupyter Notebook with IPEX or ITEX.
 
 .. note::
 
-   To launch an Intel GPU-enabled notebook, you must first :ref:`enable_intel_gpu`.
+   To launch an Intel GPU-enabled notebook, you must first :doc:`Enable Intel GPUs <../how-to/enable-gpus/enable-intel-gpu>`.
 
 To see the list of available Intel images, run:
 
@@ -109,7 +109,25 @@ Select one of them and create a notebook as follows:
 
 .. code-block:: bash
 
-   dss create my-ipex-notebook --image=intel-pytorch
+   dss create my-itex-notebook --image=intel-tensorflow
+
+Confirm the devices are detected and usable by running:
+
+.. code-block:: python
+
+   import tensorflow as tf
+
+   tf.config.experimental.list_physical_devices()
+
+Example of the expected output for a host system containing an Intel CPU and a single Intel GPU:
+
+.. code-block:: python
+
+    [PhysicalDevice(name='/physical_device:CPU:0', device_type='CPU'), PhysicalDevice(name='/physical_device:XPU:0', device_type='XPU')]
+
+.. note::
+
+    Intel calls GPU+CPU mode XPU
 
 List created notebooks
 ----------------------

--- a/docs/how-to/jupyter-notebook.rst
+++ b/docs/how-to/jupyter-notebook.rst
@@ -86,7 +86,7 @@ Confirm the GPU is detected and usable by running:
 Create an Intel GPU-enabled notebook
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can create an Intel GPU-enabled Jupyter Notebook with IPEX or ITEX.
+You can create an Intel GPU-enabled Jupyter Notebook with `Intel Extension for PyTorch`_ (IPEX) or `Intel Extension for TensorFlow`_ (ITEX).
 
 .. note::
 

--- a/docs/how-to/jupyter-notebook.rst
+++ b/docs/how-to/jupyter-notebook.rst
@@ -90,7 +90,7 @@ You can create an Intel GPU-enabled Jupyter Notebook with IPEX or ITEX.
 
 .. note::
 
-   To launch an Intel GPU-enabled notebook, you must first :doc:`Enable Intel GPUs <../how-to/enable-gpus/enable-intel-gpu>`.
+   To launch an Intel GPU-enabled notebook, you must first :ref:`enable_intel_gpu`.
 
 To see the list of available Intel images, run:
 
@@ -111,7 +111,7 @@ Select one of them and create a notebook as follows:
 
    dss create my-itex-notebook --image=intel-tensorflow
 
-Confirm the devices are detected and usable by running:
+Confirm the GPU is detected and usable by running:
 
 .. code-block:: python
 
@@ -119,7 +119,7 @@ Confirm the devices are detected and usable by running:
 
    tf.config.experimental.list_physical_devices()
 
-Example of the expected output for a host system containing an Intel CPU and a single Intel GPU:
+For example, you should expect an output like the following for a host system containing an Intel CPU and a single Intel GPU:
 
 .. code-block:: python
 
@@ -127,7 +127,7 @@ Example of the expected output for a host system containing an Intel CPU and a s
 
 .. note::
 
-    Intel calls GPU+CPU mode XPU
+    Intel denotes XPU the combination of an Intel CPU with GPU.
 
 List created notebooks
 ----------------------

--- a/docs/how-to/jupyter-notebook.rst
+++ b/docs/how-to/jupyter-notebook.rst
@@ -47,7 +47,7 @@ You should expect an output like this:
 Create an NVIDIA GPU-enabled notebook
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can create a Jupyter Notebook containing CUDA runtimes and ML frameworks, and access its JupyterLab server.
+You can create an NVIDIA GPU-enabled Jupyter Notebook containing CUDA runtimes and ML frameworks, and access its JupyterLab server.
 
 .. note::
 
@@ -86,7 +86,8 @@ Confirm the GPU is detected and usable by running:
 Create an Intel GPU-enabled notebook
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can create an Intel GPU-enabled Jupyter Notebook with `Intel Extension for PyTorch`_ (IPEX) or `Intel Extension for TensorFlow`_ (ITEX).
+You can create an Intel GPU-enabled Jupyter Notebook with `Intel Extension for PyTorch (IPEX) <https://github.com/intel/intel-extension-for-pytorch?tab=readme-ov-file#intel-extension-for-pytorch>`_ 
+or `Intel Extension for TensorFlow (ITEX) <https://github.com/intel/intel-extension-for-tensorflow?tab=readme-ov-file#intel-extension-for-tensorflow>`_.
 
 .. note::
 

--- a/docs/how-to/jupyter-notebook.rst
+++ b/docs/how-to/jupyter-notebook.rst
@@ -90,7 +90,7 @@ You can create an Intel GPU-enabled Jupyter Notebook with IPEX or ITEX.
 
 .. note::
 
-   To launch an Intel GPU-enabled notebook, you must first :doc:`Enable Intel GPUs <../how-to/enable-gpus/enable-intel-gpu>`.
+   To launch an Intel GPU-enabled notebook, you must first :ref:`enable_intel_gpu`.
 
 To see the list of available Intel images, run:
 

--- a/docs/how-to/jupyter-notebook.rst
+++ b/docs/how-to/jupyter-notebook.rst
@@ -44,14 +44,14 @@ You should expect an output like this:
     [INFO] Success: Notebook test-notebook created successfully.
     [INFO] Access the notebook at http://10.152.183.42:80.
 
-Create a GPU-enabled notebook
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Create an NVIDIA GPU-enabled notebook
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can create a Jupyter Notebook containing CUDA runtimes and ML frameworks, and access its JupyterLab server.
 
 .. note::
 
-   To launch a GPU-enabled notebook, you must first :ref:`install <install_nvidia_operator>`
+   To launch an NVIDIA GPU-enabled notebook, you must first :ref:`install <install_nvidia_operator>`
    the NVIDIA Operator and :ref:`verify <verify_nvidia_operator>` DSS can detect the GPU.
    See :ref:`nvidia_gpu` for more details.
 
@@ -82,6 +82,34 @@ Confirm the GPU is detected and usable by running:
    import tensorflow as tf
 
    tf.config.list_physical_devices('GPU')
+
+Create an Intel GPU-enabled notebook
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can create an Intel GPU-enabled Jupyter Notebook with IPEX or ITEX.
+
+.. note::
+
+   To launch an Intel GPU-enabled notebook, you must first :ref:`enable_intel_gpu`.
+
+To see the list of available Intel images, run:
+
+.. code-block:: bash
+
+   dss create --help | grep intel
+
+You should see an output similar to this:
+
+.. code-block:: bash
+
+        - intel-pytorch = intel/intel-extension-for-pytorch:2.1.20-xpu-idp-jupyter
+        - intel-tensorflow = intel/intel-extension-for-tensorflow:2.15.0-xpu-idp-jupyter
+
+Select one of them and create a notebook as follows:
+
+.. code-block:: bash
+
+   dss create my-ipex-notebook --image=intel-pytorch
 
 List created notebooks
 ----------------------

--- a/docs/how-to/jupyter-notebook.rst
+++ b/docs/how-to/jupyter-notebook.rst
@@ -90,7 +90,7 @@ You can create an Intel GPU-enabled Jupyter Notebook with IPEX or ITEX.
 
 .. note::
 
-   To launch an Intel GPU-enabled notebook, you must first :ref:`enable_intel_gpu`.
+   To launch an Intel GPU-enabled notebook, you must first :doc:`Enable Intel GPUs <../how-to/enable-gpus/enable-intel-gpu>`.
 
 To see the list of available Intel images, run:
 

--- a/docs/reuse/links.txt
+++ b/docs/reuse/links.txt
@@ -7,6 +7,8 @@
 .. _Code of conduct: https://ubuntu.com/community/ethos/code-of-conduct
 .. _Contribute: https://github.com/canonical/data-science-stack/blob/main/CONTRIBUTING.md
 .. _Discourse Forum: https://discourse.charmhub.io/tag/data-science-stack
+.. _Intel Extension for PyTorch: https://github.com/intel/intel-extension-for-pytorch?tab=readme-ov-file#intel-extension-for-pytorch
+.. _Intel Extension for TensorFlow: https://github.com/intel/intel-extension-for-tensorflow?tab=readme-ov-file#intel-extension-for-tensorflow
 .. _Join our online chat: https://matrix.to/#/#dss:ubuntu.com
 .. _Jupyter Notebooks: https://jupyter.org/
 .. _MicroK8s: https://microk8s.io/

--- a/docs/reuse/links.txt
+++ b/docs/reuse/links.txt
@@ -7,8 +7,6 @@
 .. _Code of conduct: https://ubuntu.com/community/ethos/code-of-conduct
 .. _Contribute: https://github.com/canonical/data-science-stack/blob/main/CONTRIBUTING.md
 .. _Discourse Forum: https://discourse.charmhub.io/tag/data-science-stack
-.. _Intel Extension for PyTorch: https://github.com/intel/intel-extension-for-pytorch?tab=readme-ov-file#intel-extension-for-pytorch
-.. _Intel Extension for TensorFlow: https://github.com/intel/intel-extension-for-tensorflow?tab=readme-ov-file#intel-extension-for-tensorflow
 .. _Join our online chat: https://matrix.to/#/#dss:ubuntu.com
 .. _Jupyter Notebooks: https://jupyter.org/
 .. _MicroK8s: https://microk8s.io/


### PR DESCRIPTION
closes #149 

Note to reviewer: I'm referencing the guide from PR #160 that is not merged yet so the documentation build is expected to fail