### PR TITLE
Remove `[INFO]` prefix from stdout logs

### DIFF
--- a/docs/how-to/dss.rst
+++ b/docs/how-to/dss.rst
@@ -48,11 +48,11 @@ You should expect an output like this:
 
 .. code-block:: none
 
-    [INFO] Executing initialize command
-    [INFO] Storing provided kubeconfig to /home/user/.dss/config
-    [INFO] Waiting for deployment mlflow in namespace dss to be ready...
-    [INFO] Deployment mlflow in namespace dss is ready
-    [INFO] DSS initialized. To create your first notebook run the command:
+    Executing initialize command
+    Storing provided kubeconfig to /home/user/.dss/config
+    Waiting for deployment mlflow in namespace dss to be ready...
+    Deployment mlflow in namespace dss is ready
+    DSS initialized. To create your first notebook run the command:
 
     dss create
 
@@ -87,8 +87,8 @@ You should expect an output like this:
 
 .. code-block:: none
 
-    [INFO] Waiting for namespace dss to be deleted...
-    [INFO] Success: All DSS components and notebooks purged successfully from the Kubernetes cluster.
+    Waiting for namespace dss to be deleted...
+    Success: All DSS components and notebooks purged successfully from the Kubernetes cluster.
 
 Get DSS status
 --------------
@@ -104,9 +104,9 @@ If you already have a DSS environment running and no GPU available, the expected
 
 .. code-block:: none
 
-    [INFO] MLflow deployment: Ready
-    [INFO] MLflow URL: http://10.152.183.68:5000
-    [INFO] GPU acceleration: Disabled
+    MLflow deployment: Ready
+    MLflow URL: http://10.152.183.68:5000
+    GPU acceleration: Disabled
 
 List DSS commands
 -----------------

--- a/docs/how-to/enable-gpus/enable-intel-gpu.rst
+++ b/docs/how-to/enable-gpus/enable-intel-gpu.rst
@@ -103,10 +103,10 @@ You should expect an output like this:
 .. code-block:: bash
                 
   Output:
-  [INFO] MLflow deployment: Ready
-  [INFO] MLflow URL: http://10.152.183.68:5000
-  [INFO] NVIDIA GPU acceleration: Disabled
-  [INFO] Intel GPU acceleration: Enabled
+  MLflow deployment: Ready
+  MLflow URL: http://10.152.183.68:5000
+  NVIDIA GPU acceleration: Disabled
+  Intel GPU acceleration: Enabled
 
 See also
 --------

--- a/docs/how-to/enable-gpus/enable-nvidia-gpu.rst
+++ b/docs/how-to/enable-gpus/enable-nvidia-gpu.rst
@@ -121,9 +121,9 @@ You should expect an output like this:
 
 .. code-block:: bash
 
-  [INFO] MLflow deployment: Ready
-  [INFO] MLflow URL: http://10.152.183.74:5000
-  [INFO] GPU acceleration: Enabled (NVIDIA-GeForce-RTX-3070-Ti)
+  MLflow deployment: Ready
+  MLflow URL: http://10.152.183.74:5000
+  GPU acceleration: Enabled (NVIDIA-GeForce-RTX-3070-Ti)
 
 .. note::
 

--- a/docs/how-to/jupyter-notebook.rst
+++ b/docs/how-to/jupyter-notebook.rst
@@ -38,11 +38,11 @@ You should expect an output like this:
 
 .. code-block:: none
 
-    [INFO] Executing create command
-    [INFO] Waiting for deployment test-notebook in namespace dss to be ready...
-    [INFO] Deployment test-notebook in namespace dss is ready
-    [INFO] Success: Notebook test-notebook created successfully.
-    [INFO] Access the notebook at http://10.152.183.42:80.
+    Executing create command
+    Waiting for deployment test-notebook in namespace dss to be ready...
+    Deployment test-notebook in namespace dss is ready
+    Success: Notebook test-notebook created successfully.
+    Access the notebook at http://10.152.183.42:80.
 
 Create an NVIDIA GPU-enabled notebook
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -342,26 +342,26 @@ You should expect an output like this:
 
 .. code-block:: none
 
-    [INFO] Logs for my-notebook-8cf4d9bc-jm9zm:
-    [INFO] s6-rc: info: service s6rc-oneshot-runner: starting
-    [INFO] s6-rc: info: service s6rc-oneshot-runner successfully started
-    [INFO] s6-rc: info: service fix-attrs: starting
-    [INFO] s6-rc: info: service fix-attrs successfully started
-    [INFO] s6-rc: info: service legacy-cont-init: starting
-    [INFO] cont-init: info: running /etc/cont-init.d/01-copy-tmp-home
-    [INFO] cont-init: info: /etc/cont-init.d/01-copy-tmp-home exited 0
-    [INFO] s6-rc: info: service legacy-cont-init successfully started
-    [INFO] s6-rc: info: service legacy-services: starting
-    [INFO] services-up: info: copying legacy longrun jupyterlab (no readiness notification)
-    [INFO] s6-rc: info: service legacy-services successfully started
-    [INFO] [W 2024-04-30 13:44:20.991 ServerApp] ServerApp.token config is deprecated in 2.0. Use IdentityProvider.token.
-    [INFO] [I 2024-04-30 13:44:20.996 ServerApp] Package jupyterlab took 0.0000s to import
-    [INFO] [I 2024-04-30 13:44:20.997 ServerApp] Package jupyter_server_fileid took 0.0013s to import
-    [INFO] [I 2024-04-30 13:44:20.998 ServerApp] Package jupyter_server_mathjax took 0.0007s to import
-    [INFO] [I 2024-04-30 13:44:21.001 ServerApp] Package jupyter_server_terminals took 0.0024s to import
-    [INFO] [I 2024-04-30 13:44:21.012 ServerApp] Package jupyter_server_ydoc took 0.0105s to import
-    [INFO] [I 2024-04-30 13:44:21.022 ServerApp] Package jupyterlab_git took 0.0104s to import
-    [INFO] [I 2024-04-30 13:44:21.022 ServerApp] Package nbclassic took 0.0000s to import
+    Logs for my-notebook-8cf4d9bc-jm9zm:
+    s6-rc: info: service s6rc-oneshot-runner: starting
+    s6-rc: info: service s6rc-oneshot-runner successfully started
+    s6-rc: info: service fix-attrs: starting
+    s6-rc: info: service fix-attrs successfully started
+    s6-rc: info: service legacy-cont-init: starting
+    cont-init: info: running /etc/cont-init.d/01-copy-tmp-home
+    cont-init: info: /etc/cont-init.d/01-copy-tmp-home exited 0
+    s6-rc: info: service legacy-cont-init successfully started
+    s6-rc: info: service legacy-services: starting
+    services-up: info: copying legacy longrun jupyterlab (no readiness notification)
+    s6-rc: info: service legacy-services successfully started
+    [W 2024-04-30 13:44:20.991 ServerApp] ServerApp.token config is deprecated in 2.0. Use IdentityProvider.token.
+    [I 2024-04-30 13:44:20.996 ServerApp] Package jupyterlab took 0.0000s to import
+    [I 2024-04-30 13:44:20.997 ServerApp] Package jupyter_server_fileid took 0.0013s to import
+    [I 2024-04-30 13:44:20.998 ServerApp] Package jupyter_server_mathjax took 0.0007s to import
+    [I 2024-04-30 13:44:21.001 ServerApp] Package jupyter_server_terminals took 0.0024s to import
+    [I 2024-04-30 13:44:21.012 ServerApp] Package jupyter_server_ydoc took 0.0105s to import
+    [I 2024-04-30 13:44:21.022 ServerApp] Package jupyterlab_git took 0.0104s to import
+    [I 2024-04-30 13:44:21.022 ServerApp] Package nbclassic took 0.0000s to import
 
 .. _notebook-mlflow:
 

--- a/docs/how-to/mlflow.rst
+++ b/docs/how-to/mlflow.rst
@@ -30,8 +30,8 @@ For example:
 
 .. code-block:: none
 
-    [INFO] MLflow deployment: Ready
-    [INFO] MLflow URL: http://10.152.183.205:5000
+    MLflow deployment: Ready
+    MLflow URL: http://10.152.183.205:5000
 
 .. note::
 
@@ -58,14 +58,14 @@ You should expect an output like this:
 
 .. code-block:: none
 
-    [INFO] Logs for mlflow-6bbfc5db5-xlfvj:
-    [INFO] [2024-04-30 07:57:54 +0000] [22] [INFO] Starting gunicorn 20.1.0
-    [INFO] [2024-04-30 07:57:54 +0000] [22] [INFO] Listening at: http://0.0.0.0:5000 (22)
-    [INFO] [2024-04-30 07:57:54 +0000] [22] [INFO] Using worker: sync
-    [INFO] [2024-04-30 07:57:54 +0000] [23] [INFO] Booting worker with pid: 23
-    [INFO] [2024-04-30 07:57:54 +0000] [24] [INFO] Booting worker with pid: 24
-    [INFO] [2024-04-30 07:57:54 +0000] [25] [INFO] Booting worker with pid: 25
-    [INFO] [2024-04-30 07:57:54 +0000] [26] [INFO] Booting worker with pid: 26
+    Logs for mlflow-6bbfc5db5-xlfvj:
+    [2024-04-30 07:57:54 +0000] [22] [INFO] Starting gunicorn 20.1.0
+    [2024-04-30 07:57:54 +0000] [22] [INFO] Listening at: http://0.0.0.0:5000 (22)
+    [2024-04-30 07:57:54 +0000] [22] [INFO] Using worker: sync
+    [2024-04-30 07:57:54 +0000] [23] [INFO] Booting worker with pid: 23
+    [2024-04-30 07:57:54 +0000] [24] [INFO] Booting worker with pid: 24
+    [2024-04-30 07:57:54 +0000] [25] [INFO] Booting worker with pid: 25
+    [2024-04-30 07:57:54 +0000] [26] [INFO] Booting worker with pid: 26
 
 
 Get MLflow artefacts

--- a/docs/tutorial/getting-started.rst
+++ b/docs/tutorial/getting-started.rst
@@ -62,13 +62,13 @@ Next, you need to initialise DSS on top of MicroK8s and prepare MLflow:
 
    The initialisation might take a few minutes to complete.
    While the process is in progress, you will see the following message:
-   ``[INFO] Waiting for deployment mlflow in namespace dss to be ready...``
+   ``Waiting for deployment mlflow in namespace dss to be ready...``
 
 Once initialised, you should see an output like this:
 
 .. code-block:: none
 
-   [INFO] Deployment mlflow in namespace dss is ready
+   Deployment mlflow in namespace dss is ready
    
 Launch a Notebook
 -----------------
@@ -87,11 +87,11 @@ For example, you should expect an output like this:
 
 .. code-block:: none
 
-   [INFO] Executing create command
-   [INFO] Waiting for deployment my-tensorflow-notebook in namespace dss to be ready...
-   [INFO] Deployment my-tensorflow-notebook in namespace dss is ready
-   [INFO] Success: Notebook my-tensorflow-notebook created successfully.
-   [INFO] Access the notebook at http://10.152.183.42:80.
+   Executing create command
+   Waiting for deployment my-tensorflow-notebook in namespace dss to be ready...
+   Deployment my-tensorflow-notebook in namespace dss is ready
+   Success: Notebook my-tensorflow-notebook created successfully.
+   Access the notebook at http://10.152.183.42:80.
 
 Once you know the URL, open a web browser and enter the URL into the address bar. 
 This will direct you to the notebook UI where you can start working with your notebook.

--- a/src/dss/logger.py
+++ b/src/dss/logger.py
@@ -7,7 +7,7 @@ from logging.handlers import RotatingFileHandler
 class CustomFormatter(logging.Formatter):
     """Custom formatter to adjust format based on log level."""
 
-    def format(self, record: logging.LogRecord) -> str:
+    def format(self, record: logging.LogRecord) -> str:  # noqa: A003
         # Check if the log level is INFO and remove the brackets if so
         if record.levelname == "INFO":
             self._style._fmt = "%(message)s"

--- a/src/dss/logger.py
+++ b/src/dss/logger.py
@@ -3,54 +3,73 @@ import os
 import sys
 from logging.handlers import RotatingFileHandler
 
+class InfoFilter(logging.Filter):
+    """Filter to remove [INFO] level name in console output."""
+    
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno == logging.INFO:
+            record.levelname = ''  # Remove level name for INFO
+        return True
+
+class CustomFormatter(logging.Formatter):
+    """Custom formatter to adjust format based on log level."""
+    
+    def format(self, record: logging.LogRecord) -> str:
+        if not record.levelname:  # Skip brackets if levelname is empty
+            self._style._fmt = "%(message)s"
+        else:
+            self._style._fmt = "[%(levelname)s] %(message)s"
+        return super().format(record)
 
 def setup_logger(
-    log_file_path: str, file_log_level: int = logging.DEBUG, console_log_level: int = logging.INFO
+    log_file_path: str, 
+    file_log_level: int = logging.DEBUG, 
+    console_log_level: int = logging.INFO
 ) -> logging.Logger:
     """
-    Set up a logger with a file handler and console handler.
-
+    Set up a logger with both file and console handlers.
+    
     Args:
         log_file_path (str): Path to the log file.
         file_log_level (int, optional): Logging level for file logs. Defaults to logging.DEBUG.
         console_log_level (int, optional): Logging level for console logs. Defaults to logging.INFO.
-
+        
     Returns:
         logging.Logger: Configured logger object.
     """
     logger = logging.getLogger(__name__)
 
-    # Check if the logger already has handlers to avoid duplication
     if not logger.handlers:
         logger.setLevel(file_log_level)
 
-        # Create console formatter
-        console_formatter = logging.Formatter(
+        # Formatter for console - omits [INFO]
+        console_formatter = CustomFormatter(
             "[%(levelname)s] %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
 
-        # Create file formatter
+        # Formatter for file - includes [INFO]
         file_formatter = logging.Formatter(
             "%(asctime)s [%(levelname)s] [%(module)s] [%(funcName)s]: %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
 
-        # Create the log directory if it doesn't exist
+        # Ensure the log directory exists
         if not os.path.exists(os.path.dirname(log_file_path)):
             os.makedirs(os.path.dirname(log_file_path))
 
-        # Create file handler
+        # File handler setup
         file_handler = RotatingFileHandler(log_file_path, maxBytes=5 * 1024 * 1024, backupCount=5)
         file_handler.setLevel(file_log_level)
         file_handler.setFormatter(file_formatter)
 
-        # Create console handler
+        # Console handler setup
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setLevel(console_log_level)
         console_handler.setFormatter(console_formatter)
+        console_handler.addFilter(InfoFilter())  # Apply filter to remove [INFO]
 
-        # Add handlers to the logger
+        # Add handlers to logger
         logger.addHandler(file_handler)
         logger.addHandler(console_handler)
 

--- a/src/dss/logger.py
+++ b/src/dss/logger.py
@@ -3,37 +3,30 @@ import os
 import sys
 from logging.handlers import RotatingFileHandler
 
-class InfoFilter(logging.Filter):
-    """Filter to remove [INFO] level name in console output."""
-    
-    def filter(self, record: logging.LogRecord) -> bool:
-        if record.levelno == logging.INFO:
-            record.levelname = ''  # Remove level name for INFO
-        return True
 
 class CustomFormatter(logging.Formatter):
     """Custom formatter to adjust format based on log level."""
-    
+
     def format(self, record: logging.LogRecord) -> str:
-        if not record.levelname:  # Skip brackets if levelname is empty
+        # Check if the log level is INFO and remove the brackets if so
+        if record.levelname == "INFO":
             self._style._fmt = "%(message)s"
         else:
             self._style._fmt = "[%(levelname)s] %(message)s"
         return super().format(record)
 
+
 def setup_logger(
-    log_file_path: str, 
-    file_log_level: int = logging.DEBUG, 
-    console_log_level: int = logging.INFO
+    log_file_path: str, file_log_level: int = logging.DEBUG, console_log_level: int = logging.INFO
 ) -> logging.Logger:
     """
     Set up a logger with both file and console handlers.
-    
+
     Args:
         log_file_path (str): Path to the log file.
         file_log_level (int, optional): Logging level for file logs. Defaults to logging.DEBUG.
         console_log_level (int, optional): Logging level for console logs. Defaults to logging.INFO.
-        
+
     Returns:
         logging.Logger: Configured logger object.
     """
@@ -67,7 +60,6 @@ def setup_logger(
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setLevel(console_log_level)
         console_handler.setFormatter(console_formatter)
-        console_handler.addFilter(InfoFilter())  # Apply filter to remove [INFO]
 
         # Add handlers to logger
         logger.addHandler(file_handler)

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -51,9 +51,9 @@ def get_log_file_path(logger: logging.Logger) -> Optional[str]:
 @pytest.mark.parametrize(
     "log_level, log_message, expected_prefix",
     [
+        (logging.DEBUG, "This is a debug message", "[DEBUG]"),
         (logging.INFO, "This is an info message", "[INFO]"),
         (logging.WARNING, "This is a warning message", "[WARNING]"),
-        (logging.DEBUG, "This is a debug message", "[DEBUG]"),
         (logging.ERROR, "This is an error message", "[ERROR]"),
     ],
 )

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,0 +1,107 @@
+import logging
+import os
+import uuid
+from typing import Generator, Optional
+
+import pytest
+
+from dss.logger import setup_logger  # Adjust with your actual module name
+
+
+@pytest.fixture(scope="function")
+def logger_setup(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[logging.Logger, None, None]:
+    """Fixture to set up a unique logger with a log file for the test."""
+    # Generate a random and unique logger name to avoid conflicts
+    unique_logger_name = f"test_logger_{uuid.uuid4().hex}"
+
+    # Set a static log file name, unique to each test
+    log_file_name = "test_log.log"
+    log_file_path = tmp_path_factory.mktemp("logs") / log_file_name
+
+    # Create a unique logger instance
+    logger = logging.getLogger(unique_logger_name)
+
+    # Clear any existing handlers (if reusing logger names between tests)
+    logger.handlers.clear()
+
+    logger = setup_logger(
+        log_file_path=str(log_file_path),
+    )
+
+    # Force creation of the log file by logging an empty message
+    logger.debug("Logger initialized")
+
+    yield logger
+
+    # Cleanup: remove the log file after the test is done
+    if log_file_path.exists():
+        os.remove(log_file_path)
+
+
+def get_log_file_path(logger: logging.Logger) -> Optional[str]:
+    """Helper function to get the file path of the log file used by the logger."""
+    for handler in logger.handlers:
+        if isinstance(handler, logging.FileHandler):
+            return handler.baseFilename
+    return None
+
+
+@pytest.mark.parametrize(
+    "log_level, log_message, expected_prefix",
+    [
+        (logging.INFO, "This is an info message", "[INFO]"),
+        (logging.WARNING, "This is a warning message", "[WARNING]"),
+        (logging.DEBUG, "This is a debug message", "[DEBUG]"),
+        (logging.ERROR, "This is an error message", "[ERROR]"),
+    ],
+)
+def test_file_logs(
+    logger_setup: logging.Logger, log_level: int, log_message: str, expected_prefix: str
+) -> None:
+    """Test that logs include the correct prefix in the file output."""
+    logger = logger_setup
+
+    logger.log(log_level, log_message)
+
+    log_file_path = get_log_file_path(logger)
+    assert log_file_path is not None, "Log file path could not be determined."
+
+    with open(log_file_path, "r") as f:
+        log_contents = f.read().strip()
+
+    assert expected_prefix in log_contents
+    assert log_message in log_contents
+
+
+@pytest.mark.parametrize(
+    "log_level, log_message, expected_prefix",
+    [
+        (logging.INFO, "This is an info message", ""),  # No prefix for INFO in console
+        (logging.WARNING, "This is a warning message", "[WARNING]"),
+        (logging.ERROR, "This is an error message", "[ERROR]"),
+    ],
+)
+def test_console_logs(
+    logger_setup: logging.Logger,
+    capfd: pytest.CaptureFixture,
+    log_level: int,
+    log_message: str,
+    expected_prefix: str,
+) -> None:
+    """Test that logs include the correct prefix in the console output."""
+    logger = logger_setup
+
+    logger.log(log_level, log_message)
+
+    # Capture stdout output
+    captured = capfd.readouterr()
+
+    # Assert that the output includes the correct prefix (or lack of it for INFO)
+    if expected_prefix:
+        assert expected_prefix in captured.out
+    else:
+        assert "[INFO]" not in captured.out  # Ensure no [INFO] prefix
+
+    assert log_message in captured.out


### PR DESCRIPTION
Closes: https://github.com/canonical/data-science-stack/issues/158

- Removing `[INFO] ` prefix from stdout logs. We want to keep it in the logs file. 
- Changing docs to reflwct the change
- Adding unit tests for logger

How to test:
```
git clone <repo>
cd <repo>
pip install .
dss status
```

The logs in console should not have `[INFO]`