### PR TITLE
Remove repeated output while waiting for deployment

### DIFF
--- a/src/dss/utils.py
+++ b/src/dss/utils.py
@@ -99,8 +99,11 @@ def wait_for_deployment_ready(
             raise TimeoutError(
                 f"Timeout waiting for deployment {deployment_name} in namespace {namespace} to be ready"  # noqa E501
             )
-
-        time.sleep(interval_seconds)
+        else:
+            time.sleep(interval_seconds)
+            logger.debug(
+                f"Waiting for deployment {deployment_name} in namespace {namespace} to be ready..."
+            )
 
 
 def get_kubeconfig_path(

--- a/src/dss/utils.py
+++ b/src/dss/utils.py
@@ -99,11 +99,8 @@ def wait_for_deployment_ready(
             raise TimeoutError(
                 f"Timeout waiting for deployment {deployment_name} in namespace {namespace} to be ready"  # noqa E501
             )
-        else:
-            time.sleep(interval_seconds)
-            logger.info(
-                f"Waiting for deployment {deployment_name} in namespace {namespace} to be ready..."
-            )
+
+        time.sleep(interval_seconds)
 
 
 def get_kubeconfig_path(


### PR DESCRIPTION
Closes: https://github.com/canonical/data-science-stack/issues/159

Because there is shared function for waiting for any deployment to be ready we only had to change code in one place :) 

Manual test:
```
git clone <repo>
cd <repo>
pip install .
dss initialize --kubeconfig="$(sudo microk8s config)"
dss create my-notebook --image=pytorch
```

The message `Waiting for deployment <deployment-name> in namespace dss to be ready...` should appear only once in both cases.
