### PR TITLE
Add note to docs for microk8s kubeconfig initialisation for kubectl snap

### DIFF
--- a/docs/how-to/enable-gpus/enable-intel-gpu.rst
+++ b/docs/how-to/enable-gpus/enable-intel-gpu.rst
@@ -14,7 +14,15 @@ Prerequisites
 * DSS is :ref:`installed <install_DSS_CLI>` and :ref:`initialised <initialise_DSS>`.
 * The `kubectl snap <https://snapcraft.io/kubectl>`_ package is installed.
 * Your machine includes an Intel GPU.
-  
+
+.. note::
+   After installing `kubectl`, configure MicroK8s to run `kubectl` commands as follows:
+
+   .. code-block:: bash
+
+      mkdir -p ~/.kube
+      microk8s config > ~/.kube/config 
+
 Verify the Intel GPU drivers
 ----------------------------------------------------------
 
@@ -54,15 +62,6 @@ To ensure DSS can utilise Intel GPUs, you have to enable the Intel GPU plugin in
   kubectl kustomize https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/nfd?ref=${VERSION} > node_feature_discovery.yaml
   kubectl kustomize https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/nfd/overlays/node-feature-rules?ref=${VERSION} > node_feature_rules.yaml
   kubectl kustomize https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/gpu_plugin/overlays/nfd_labeled_nodes?ref=${VERSION} > gpu_plugin.yaml
-
-.. note::
-   To use `kubectl` commands with MicroK8s, ensure your Kubernetes configuration is set up correctly. 
-   After installing the `kubectl` snap, run the following commands to configure it:
-
-   .. code-block:: bash
-
-      mkdir -p ~/.kube
-      microk8s config > ~/.kube/config 
 
 To allow multiple containers to utilise the same GPU, run:
 

--- a/docs/how-to/enable-gpus/enable-intel-gpu.rst
+++ b/docs/how-to/enable-gpus/enable-intel-gpu.rst
@@ -55,6 +55,15 @@ To ensure DSS can utilise Intel GPUs, you have to enable the Intel GPU plugin in
   kubectl kustomize https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/nfd/overlays/node-feature-rules?ref=${VERSION} > node_feature_rules.yaml
   kubectl kustomize https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/gpu_plugin/overlays/nfd_labeled_nodes?ref=${VERSION} > gpu_plugin.yaml
 
+.. note::
+   To use `kubectl` commands with MicroK8s, ensure your Kubernetes configuration is set up correctly. 
+   After installing the `kubectl` snap, run the following commands to configure it:
+
+   .. code-block:: bash
+
+      mkdir -p ~/.kube
+      microk8s config > ~/.kube/config 
+
 To allow multiple containers to utilise the same GPU, run:
 
 .. code-block:: bash


### PR DESCRIPTION
Closes: https://github.com/canonical/data-science-stack/issues/167

Adds note about micork8s kubeconfig initialisation in the docs