### PR TITLE
Build for arch=all to run on all architectures

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,6 +9,7 @@ base: core22
 confinement: strict
 architectures:
   - build-on: amd64
+  - build-on: arm64
 
 apps:
   dss:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,8 +8,8 @@ adopt-info: data-science-stack-version
 base: core22
 confinement: strict
 architectures:
-  - build-on: amd64
-  - build-on: arm64
+  - build-on: [amd64]
+    build-for: [all]
 
 apps:
   dss:


### PR DESCRIPTION
There is nothing architecture specific, so we should build to run on all.