### PR TITLE
Fix MLflow deployment for Canonical k8s

### DIFF
--- a/poc/common-manifests/mlflow.yaml
+++ b/poc/common-manifests/mlflow.yaml
@@ -31,6 +31,17 @@ spec:
       labels:
         app: dss-mlflow
     spec:
+      initContainers:
+        - name: remove-problematic-folder
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              rm -rf /mlruns/lost+found/
+          volumeMounts:
+            - name: mlflow
+              mountPath: /mlruns
       containers:
         - name: mlflow-container
           image: ubuntu/mlflow:2.1.1_1.0-22.04

--- a/poc/common-manifests/notebooks.yaml
+++ b/poc/common-manifests/notebooks.yaml
@@ -12,5 +12,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: microk8s-hostpath
   volumeMode: Filesystem

--- a/src/dss/manifest_templates/dss_core.yaml.j2
+++ b/src/dss/manifest_templates/dss_core.yaml.j2
@@ -17,5 +17,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: microk8s-hostpath
   volumeMode: Filesystem

--- a/src/dss/manifest_templates/mlflow_deployment.yaml.j2
+++ b/src/dss/manifest_templates/mlflow_deployment.yaml.j2
@@ -36,6 +36,17 @@ spec:
         app.kubernetes.io/name: {{ mlflow_name }}
         app.kubernetes.io/part-of: dss
     spec:
+      initContainers:
+        - name: remove-problematic-folder
+          image: busybox
+          command:
+            - sh
+            - -c
+            - |
+              rm -rf /mlruns/lost+found/
+          volumeMounts:
+            - name: mlflow
+              mountPath: /mlruns
       containers:
         - name: mlflow
           image: ubuntu/mlflow:2.1.1_1.0-22.04

--- a/src/dss/manifest_templates/mlflow_deployment.yaml.j2
+++ b/src/dss/manifest_templates/mlflow_deployment.yaml.j2
@@ -37,7 +37,7 @@ spec:
         app.kubernetes.io/part-of: dss
     spec:
       initContainers:
-        - name: remove-problematic-folder
+        - name: remove-lost-and-found-folder
           image: busybox
           command:
             - sh


### PR DESCRIPTION
Closes: https://github.com/canonical/data-science-stack/issues/193

This PR is merged against dev branch for Canonical k8s integration. There are some other tasks which needs to be finished before merging to main. 

This change could be only tested manually. Tests are supposed to fail.
1. Deploy caonical k8s 
```
sudo snap install k8s --classic
```
2. Bootstrap
```
sudo k8s bootstrap
```
3. According to [documentation](https://documentation.ubuntu.com/canonical-kubernetes/latest/src/snap/tutorial/getting-started/#enable-local-storage) they recommend to enable local storage 
```
sudo k8s enable local-storage
```
4. Go to this repo and pack the snap 
```
snapcraft
```
5. You should be prompted with the snap file which we will now deploy to your computer.
```
sudo snap install data-science-stack_0.1-<hash>_amd64.snap --dangerous
```
6. Initialise the DSS 
```
data-science-stack.dss initialize --kubeconfig="$(echo "$(sudo k8s config)")"
```
7. Get MLflow url 
```
data-science-stack.dss status
```
You should see this 
![image](https://github.com/user-attachments/assets/2b25afb5-2d08-448a-b040-79dccd67fd04)
8. Now create an example notebook 
```
data-science-stack.dss create my-notebook-scipy --image=kubeflownotebookswg/jupyter-scipy:v1.8.0
```
9. Connect to it and create example notebook (not in the shared folder, shared folder does not have permissions yet because of this https://github.com/canonical/data-science-stack/issues/194).
10. Intall mlflow in the notebooks terminal 
```
pip install mlflow==2.1.1
```
11. Run this example code
```
import numpy as np
import pandas as pd
from sklearn.model_selection import train_test_split
from sklearn.linear_model import LinearRegression
from sklearn.metrics import mean_squared_error
import mlflow
import mlflow.sklearn

# Generate a simple dataset
np.random.seed(42)
X = np.random.rand(100, 1) * 10  # Features
y = 2.5 * X + np.random.randn(100, 1) * 2  # Labels

# Split the dataset into training and testing sets
X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)

# Start an MLflow experiment
mlflow.set_experiment("Simple Linear Regression")

with mlflow.start_run():
    # Train a linear regression model
    model = LinearRegression()
    model.fit(X_train, y_train)

    # Make predictions and evaluate the model
    y_pred = model.predict(X_test)
    mse = mean_squared_error(y_test, y_pred)

    # Log parameters, metrics, and the model
    mlflow.log_param("fit_intercept", model.fit_intercept)
    mlflow.log_metric("mse", mse)
    mlflow.sklearn.log_model(model, "model")

    print(f"Logged model with MSE: {mse}")

# Load the model back for inference
logged_model = mlflow.get_artifact_uri("model")
print(f"Model saved at: {logged_model}")
```
The code should finish with 
```
2025/01/22 08:08:28 INFO mlflow.tracking.fluent: Experiment with name 'Simple Linear Regression' does not exist. Creating a new experiment.

Logged model with MSE: 2.6147980548680083
Model saved at: mlflow-artifacts:/129803599187950381/6dfafd4e19954f0c9a5fdc91be7e2136/artifacts/model
```
12. Go back to MLflow and you should see the experiment with model.

