### PR TITLE
Fix `shared` folder on Canonical k8s

### DIFF
--- a/poc/common-manifests/notebooks.yaml
+++ b/poc/common-manifests/notebooks.yaml
@@ -12,5 +12,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: microk8s-hostpath
   volumeMode: Filesystem

--- a/src/dss/manifest_templates/dss_core.yaml.j2
+++ b/src/dss/manifest_templates/dss_core.yaml.j2
@@ -17,5 +17,4 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  storageClassName: microk8s-hostpath
   volumeMode: Filesystem

--- a/src/dss/manifest_templates/notebook_deployment.yaml.j2
+++ b/src/dss/manifest_templates/notebook_deployment.yaml.j2
@@ -19,6 +19,20 @@ spec:
         app.kubernetes.io/part-of: dss
         canonical.com/dss-notebook: {{ notebook_name }}
     spec:
+      initContainers:
+        - name: set-shared-folder-permissions
+          image: {{ notebook_image }}
+          command:
+            - sh
+            - -c
+            - |
+              chmod -R 775 /home/jovyan/shared && \
+              chown -R jovyan:users /home/jovyan/shared
+          securityContext:
+            runAsUser: 0  # Run as root
+          volumeMounts:
+            - mountPath: /home/jovyan/shared
+              name: home-volume
       containers:
         - env:
           - name: MLFLOW_TRACKING_URI


### PR DESCRIPTION
Closes: https://github.com/canonical/data-science-stack/issues/194

This PR is merged against dev branch for Canonical k8s integration. There are some other tasks which needs to be finished before merging to main. 

This change could be only tested manually. Tests are supposed to fail.
1. Deploy caonical k8s 
```
sudo snap install k8s --classic
```
2. Bootstrap
```
sudo k8s bootstrap
```
3. According to [documentation](https://documentation.ubuntu.com/canonical-kubernetes/latest/src/snap/tutorial/getting-started/#enable-local-storage) they recommend to enable local storage 
```
sudo k8s enable local-storage
```
4. Go to this repo and pack the snap 
```
snapcraft
```
5. You should be prompted with the snap file which we will now deploy to your computer.
```
sudo snap install data-science-stack_0.1-<hash>_amd64.snap --dangerous
```
6. Initialise the DSS 
```
data-science-stack.dss initialize --kubeconfig="$(echo "$(sudo k8s config)")"
```
7. Now create an example notebook 
```
data-science-stack.dss create my-notebook-scipy --image=kubeflownotebookswg/jupyter-scipy:v1.8.0
```
8. Connect to notebook. Now you should be able to create notebook file under shared folder.
