### PR TITLE
feat: run integration tests on canonical k8s

### DIFF
--- a/.github/concierge.yaml
+++ b/.github/concierge.yaml
@@ -1,0 +1,7 @@
+providers:
+  k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.32-classic/stable
+    features:
+      local-storage:

--- a/.github/concierge.yaml
+++ b/.github/concierge.yaml
@@ -1,7 +1,0 @@
-providers:
-  k8s:
-    enable: true
-    bootstrap: true
-    channel: 1.32-classic/stable
-    features:
-      local-storage:

--- a/.github/workflows/build_and_test_snap.yaml
+++ b/.github/workflows/build_and_test_snap.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - uses: snapcore/action-build@v1.2.0
+    - uses: snapcore/action-build@v1.3.0
       id: snapcraft
       with:
         # Use a deterministic file name, so we can easily reference it later

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,7 @@ jobs:
     - name: Install dependencies
       run: |
         # Removing docker as it is blocking canonical k8s bootstrap
+        # For local dev reffer to this guide https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/install/dev-env/#containerd-conflicts
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
         

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,8 +47,9 @@ jobs:
     
     - name: Install dependencies
       run: |
+        sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+        sudo rm -rf /run/containerd
         sudo snap install concierge --classic
-        systemctl stop containerd
         sudo concierge prepare --extra-snaps=kubectl -c .github/concierge.yaml
 
     - name: Run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,10 +47,12 @@ jobs:
     
     - name: Install dependencies
       run: |
+        # Removing docker as it is blocking canonical k8s bootstrap
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
+        
         sudo snap install kubectl --classic
-        sudo snap install k8s --classic
+        sudo snap install k8s --classic --channel=1.32-classic/stable
         sudo k8s bootstrap
         sudo k8s enable local-storage
         mkdir -p ~/.kube

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,8 +36,6 @@ jobs:
     # is resolved and applied to all ROCKs repositories
     - name: Install python version from input
       run: |
-        # TODO: remove when fixed: https://github.com/microsoft/linux-package-repositories/issues/130#issuecomment-2074645171
-        sudo rm /etc/apt/sources.list.d/microsoft-prod.list
         sudo add-apt-repository ppa:deadsnakes/ppa -y
         sudo apt update -y
         VERSION=3.10
@@ -47,11 +45,11 @@ jobs:
         python3.10 -m pip install tox
         rm get-pip.py
     
-    - uses: balchua/microk8s-actions@v0.3.2
-      with:
-        channel: '1.28/stable'
-        addons: '["hostpath-storage"]'
+    - name: Install dependencies
+      run: |
+        sudo snap install concierge --classic
+        sudo concierge prepare --extra-snaps=kubectl -c .github/concierge.yaml
 
-    - name: Install library
-      run: sg microk8s -c "tox -vve integration"
+    - name: Run tests
+      run: tox -vve integration
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,8 +49,12 @@ jobs:
       run: |
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
-        sudo snap install concierge --classic
-        sudo concierge prepare --extra-snaps=kubectl -c .github/concierge.yaml
+        sudo snap install kubectl --classic
+        sudo snap install k8s --classic
+        sudo k8s bootstrap
+        sudo k8s enable local-storage
+        mkdir -p ~/.kube
+        sudo k8s config > ~/.kube/config
 
     - name: Run tests
       run: tox -vve integration

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,7 +48,7 @@ jobs:
     - name: Install dependencies
       run: |
         # Removing docker as it is blocking canonical k8s bootstrap
-        # For local dev reffer to this guide https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/install/dev-env/#containerd-conflicts
+        # Based on this guide https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/install/dev-env/#containerd-conflicts
         sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
         sudo rm -rf /run/containerd
         

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -48,6 +48,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo snap install concierge --classic
+        systemctl stop containerd
         sudo concierge prepare --extra-snaps=kubectl -c .github/concierge.yaml
 
     - name: Run tests


### PR DESCRIPTION
This PR is part of https://github.com/canonical/data-science-stack/issues/198 and https://github.com/canonical/data-science-stack/issues/197

Changes:
- Install canonical k8s 
- Install Nvidia k8s operator
- Run integration tests  