### PR TITLE
fix: use security context for the mounted volumens

### DIFF
--- a/src/dss/manifest_templates/notebook_deployment.yaml.j2
+++ b/src/dss/manifest_templates/notebook_deployment.yaml.j2
@@ -19,20 +19,8 @@ spec:
         app.kubernetes.io/part-of: dss
         canonical.com/dss-notebook: {{ notebook_name }}
     spec:
-      initContainers:
-        - name: set-shared-folder-permissions
-          image: {{ notebook_image }}
-          command:
-            - sh
-            - -c
-            - |
-              chmod -R 775 /home/jovyan/shared && \
-              chown -R jovyan:users /home/jovyan/shared
-          securityContext:
-            runAsUser: 0  # Run as root
-          volumeMounts:
-            - mountPath: /home/jovyan/shared
-              name: home-volume
+      securityContext:
+        fsGroup: 1000  # Ensures group ownership for files
       containers:
         - env:
           - name: MLFLOW_TRACKING_URI


### PR DESCRIPTION
Closes: https://github.com/canonical/data-science-stack/issues/209

Manual test: 

1. Deploy caonical k8s 
```
sudo snap install k8s --classic
```
2. Bootstrap
```
sudo k8s bootstrap
```
3. According to [documentation](https://documentation.ubuntu.com/canonical-kubernetes/latest/src/snap/tutorial/getting-started/#enable-local-storage) they recommend to enable local storage 
```
sudo k8s enable local-storage
```
4. Go to this repo and pack the snap 
```
snapcraft
```
5. You should be prompted with the snap file which we will now deploy to your computer.
```
sudo snap install data-science-stack_0.1-<hash>_amd64.snap --dangerous
```
6. Initialise the DSS 
```
data-science-stack.dss initialize --kubeconfig="$(echo "$(sudo k8s config)")"
```
7. Now create an example notebook 
```
data-science-stack.dss create my-notebook-intel --image=intel/intel-extension-for-tensorflow:2.15.0-xpu-idp-jupyter
```
8. Connect to notebook. Now you should be able to create notebook file under shared folder.

Basides the ci I have tested also manually in vm.

**CI note:** Docs checks failing for unknown reason the links in the error messages a re working. I have fixed them in this separate docs pr https://github.com/canonical/data-science-stack/pull/215