### PR TITLE
feat: update docs for canonical k8s

### DIFF
--- a/docs/explanation/dss-arch.rst
+++ b/docs/explanation/dss-arch.rst
@@ -52,8 +52,8 @@ ML tools
 
 DSS includes:
 
-* Jupyter Notebooks: Open-source environment that provides a flexible interface to organize DS projects and ML workloads. 
-* MLflow: Open-source platform for managing the ML lifecycle, including experiment tracking and model registry.
+* Jupyter Notebooks: Open-source environment that provides a flexible interface to organise DS projects and ML workloads. 
+* MLflow: Open-source platform for managing the ML life cycle, including experiment tracking and model registry.
 * ML frameworks: DSS comes by default with PyTorch and TensorFlow. Users can manually add other frameworks, depending on their needs and use cases.
 
 Jupyter Notebooks
@@ -68,7 +68,7 @@ MLflow
 ^^^^^^
 
 `MLflow <https://ubuntu.com/blog/what-is-mlflow>`_ operates in `local mode <https://mlflow.org/docs/latest/tracking.html#other-configuration-with-mlflow-tracking-server>`_, 
-meaning that metadata and artifacts are, by default, stored in a local directory.
+meaning that metadata and artefacts are, by default, stored in a local directory.
 
 This local directory is backed by a persistent volume, mounted to a Hostpath directory of the MLflow Pod.
 The persistent volume can be found in the directory `/mlruns`.
@@ -103,11 +103,11 @@ It also depends on the chosen image, for example, CUDA when working with NVIDIA 
 Storage
 ^^^^^^^
 
-DSS expects a default `storage class <https://kubernetes.io/docs/concepts/storage/storage-classes/>`_ in the Kubernetes deployment, which is used to persist Jupyter Notebooks and MLflow artifacts.   
+DSS expects a default `storage class <https://kubernetes.io/docs/concepts/storage/storage-classes/>`_ in the Kubernetes deployment, which is used to persist Jupyter Notebooks and MLflow artefacts.   
 In Canonical K8s, a local storage class should be configured to provision Kubernetes' *PersistentVolumeClaims* (`PVCs <https://kubernetes.io/docs/concepts/storage/persistent-volumes/>`_). 
 
 A shared PVC is used across all Jupyter Notebooks to share and persist data. 
-MLflow also uses its dedicated PVC to store the logged artifacts.
+MLflow also uses its dedicated PVC to store the logged artefacts.
 This is the DSS default storage configuration and cannot be altered.
 
 This choice ensures that all storage is backed up on the host machine in the event of cluster restarts.
@@ -115,7 +115,7 @@ This choice ensures that all storage is backed up on the host machine in the eve
 .. note::
    By default, you can access the DSS storage anytime under your local directory `/var/snap/k8s/common/default-storage`. 
 
-The following diagram summarizes the DSS storage:
+The following diagram summarises the DSS storage:
 
 .. figure:: https://assets.ubuntu.com/v1/2130fd66-dss_storage.png
    :width: 800px

--- a/docs/explanation/dss-arch.rst
+++ b/docs/explanation/dss-arch.rst
@@ -67,7 +67,7 @@ The full path to that persistent volume is `/home/jovyan/shared`.
 MLflow
 ^^^^^^
 
-`MLflow <https://ubuntu.com/blog/what-is-mlflow>`_ operates in `local mode <https://mlflow.org/docs/latest/tracking.html#other-configuration-with-mlflow-tracking-server>`_, 
+`MLflow <https://ubuntu.com/blog/what-is-mlflow>`_ operates in `local mode <https://mlflow.org/docs/latest/tracking/#other-tracking-setup>`_, 
 meaning that metadata and artefacts are, by default, stored in a local directory.
 
 This local directory is backed by a persistent volume, mounted to a Hostpath directory of the MLflow Pod.

--- a/docs/explanation/dss-arch.rst
+++ b/docs/explanation/dss-arch.rst
@@ -1,10 +1,10 @@
 DSS architecture
 ================
 
-This guide provides an overview of the Data science stack (DSS) architecture, its main components and their interactions. 
+This guide provides an overview of the Data Science Stack (DSS) architecture, its main components, and their interactions. 
 
 DSS is a ready-to-run environment for Machine Learning (ML) and Data Science (DS). 
-It's built on open-source tooling, including `MicroK8s`_, JupyterLab and `MLflow <https://ubuntu.com/blog/what-is-mlflow>`_.
+It's built on open-source tooling, including `Canonical K8s`_, JupyterLab, and `MLflow <https://ubuntu.com/blog/what-is-mlflow>`_.
 
 DSS is distributed as a `snap`_ and usable on any Ubuntu workstation. 
 This provides robust security management and user-friendly version control, enabling seamless updates and auto-rollback in case of failure. 
@@ -19,12 +19,13 @@ Using DSS, you can perform the following tasks:
 Architecture overview
 ---------------------
 
-The DSS architecture includes these layers:
+The DSS architecture can be thought of as a stack of layers. 
+These layers, from top to bottom, include:
 
 * :ref:`Application <app_layer>`.
 * :ref:`ML tools <ml_tools>`.
 * :ref:`Orchestration <orch_layer>`.
-* :ref:`Operating system <os_layer>`.
+* :ref:`Operating system (OS) <os_layer>`.
 
 The following diagram showcases it:
 
@@ -51,14 +52,14 @@ ML tools
 
 DSS includes:
 
-* Jupyter Notebooks: Open source environment that provides a flexible interface to organise DS projects and ML workloads. 
-* MLflow: Open source platform for managing the ML life cycle, including experiment tracking and model registry.
-* ML frameworks: DSS comes by default with PyTorch and Tensorflow. Users can manually add other frameworks, depending on their needs and use cases.
+* Jupyter Notebooks: Open-source environment that provides a flexible interface to organize DS projects and ML workloads. 
+* MLflow: Open-source platform for managing the ML lifecycle, including experiment tracking and model registry.
+* ML frameworks: DSS comes by default with PyTorch and TensorFlow. Users can manually add other frameworks, depending on their needs and use cases.
 
 Jupyter Notebooks
 ^^^^^^^^^^^^^^^^^
 
-A `Jupyter Notebook <Jupyter Notebooks_>`_ is essentially a `Kubernetes deployment <Pod_>`_, also known as `Pod`, running a Docker image with Jupyter Lab and a dedicated ML framework, such as Pytorch or Tensorflow.
+A `Jupyter Notebook <Jupyter Notebooks_>`_ is essentially a `Kubernetes deployment <Pod_>`_, also known as `Pod`, running a Docker image with Jupyter Lab and a dedicated ML framework, such as PyTorch or TensorFlow.
 For each Jupyter Notebook, DSS mounts a `Hostpath <Microk8s hostpath docs_>`_ directory-backed persistent volume to the data directory. 
 All Jupyter Notebooks share the same persistent volume, allowing them to exchange data seamlessly. 
 The full path to that persistent volume is `/home/jovyan/shared`.
@@ -67,7 +68,7 @@ MLflow
 ^^^^^^
 
 `MLflow <https://ubuntu.com/blog/what-is-mlflow>`_ operates in `local mode <https://mlflow.org/docs/latest/tracking.html#other-configuration-with-mlflow-tracking-server>`_, 
-meaning that metadata and artefacts are, by default, stored in a local directory.
+meaning that metadata and artifacts are, by default, stored in a local directory.
 
 This local directory is backed by a persistent volume, mounted to a Hostpath directory of the MLflow Pod.
 The persistent volume can be found in the directory `/mlruns`.
@@ -78,12 +79,10 @@ Orchestration
 ~~~~~~~~~~~~~
 
 DSS requires a container orchestration solution. 
-DSS relies on `MicroK8s`_, a lightweight Kubernetes distribution.
+DSS relies on `Canonical K8s`_, a lightweight Kubernetes distribution.
 
-Therefore, MicroK8s needs to be deployed before installing DSS on the host machine. 
-It must be configured with the storage add-on. 
-This is required to use Hostpath storage in the cluster. 
-See :ref:`set_microk8s` to learn how to install MicroK8s.
+Therefore, Canonical K8s needs to be deployed before installing DSS on the host machine. 
+It must be configured with local storage support to handle persistent volumes used by DSS.
 
 .. _gpu_support:
 
@@ -91,14 +90,12 @@ GPU support
 ^^^^^^^^^^^
 
 DSS can run with or without the use of GPUs.
-If needed, MicroK8s can be configured with the desired `GPU add-on <https://microk8s.io/docs/addon-gpu>`_. 
-
-DSS is designed to support the deployment of containerised GPU workloads on NVIDIA GPUs. 
-MicroK8s simplifies the GPU access and usage through the `NVIDIA GPU Operator <NVIDIA Operator_>`_. 
+If needed, the NVIDIA GPU Operator should be deployed following the official documentation: 
+`NVIDIA GPU Operator <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html>`_.
 
 DSS does not automatically install the tools and libraries required for running GPU workloads.
-To do so, it relies on MicroK8s for the required operating-system drivers.
-It also relies on the chosen image, for example, CUDA when working with NVIDIA GPUs.
+It relies on Canonical K8s for the required operating-system drivers.
+It also depends on the chosen image, for example, CUDA when working with NVIDIA GPUs.
 
 .. caution::
    GPUs from other silicon vendors rather than NVIDIA can be configured. However, its functionality is not guaranteed.
@@ -106,19 +103,19 @@ It also relies on the chosen image, for example, CUDA when working with NVIDIA G
 Storage
 ^^^^^^^
 
-DSS expects a default `storage class <https://kubernetes.io/docs/concepts/storage/storage-classes/>`_ in the Kubernetes deployment, which is used to persist Jupyter Notebooks and MLflow artefacts.   
-In MicroK8s, the Hostpath storage add-on is chosen, used to provision Kubernetes' *PersistentVolumeClaims* (`PVCs <https://kubernetes.io/docs/concepts/storage/persistent-volumes/>`_). 
+DSS expects a default `storage class <https://kubernetes.io/docs/concepts/storage/storage-classes/>`_ in the Kubernetes deployment, which is used to persist Jupyter Notebooks and MLflow artifacts.   
+In Canonical K8s, a local storage class should be configured to provision Kubernetes' *PersistentVolumeClaims* (`PVCs <https://kubernetes.io/docs/concepts/storage/persistent-volumes/>`_). 
 
 A shared PVC is used across all Jupyter Notebooks to share and persist data. 
-MLflow also uses its dedicated PVC to store the logged artefacts.
+MLflow also uses its dedicated PVC to store the logged artifacts.
 This is the DSS default storage configuration and cannot be altered.
 
-This choice ensures that all storage is backed up on the host machine in the event of MicroK8s restarts.
+This choice ensures that all storage is backed up on the host machine in the event of cluster restarts.
 
 .. note::
-   By default, you can access the DSS storage anytime under your local directory `/var/snap/microk8s/common/default-storage`. 
+   By default, you can access the DSS storage anytime under your local directory `/var/snap/k8s/common/default-storage`. 
 
-The following diagram summarises the DSS storage:
+The following diagram summarizes the DSS storage:
 
 .. figure:: https://assets.ubuntu.com/v1/2130fd66-dss_storage.png
    :width: 800px
@@ -131,7 +128,7 @@ The following diagram summarises the DSS storage:
 Operating system
 ~~~~~~~~~~~~~~~~
 
-DSS is native on Ubuntu, being developed, tested and validated on it. 
+DSS is native on Ubuntu, being developed, tested, and validated on it. 
 Moreover, the solution can be used on any Linux distribution.
 
 Namespace configuration
@@ -146,8 +143,7 @@ This includes the GPU Operator for managing access and usage.
 Accessibility
 -------------
 
-Jupyter Notebooks and MLflow can be accessed from a web browser through the Pod IP that is given access through MicroK8s.
+Jupyter Notebooks and MLflow can be accessed from a web browser through the Pod IP that is given access through Canonical K8s.
 See :ref:`access_notebook` and :ref:`access_mlflow` for more details.
 
-
-
+.. _Canonical K8s: https://snapcraft.io/k8s

--- a/docs/explanation/dss-arch.rst
+++ b/docs/explanation/dss-arch.rst
@@ -90,8 +90,7 @@ GPU support
 ^^^^^^^^^^^
 
 DSS can run with or without the use of GPUs.
-If needed, the NVIDIA GPU Operator should be deployed following the official documentation: 
-`NVIDIA GPU Operator <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html>`_.
+If needed, follow `NVIDIA GPU Operator <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html>`_ for deployment details.
 
 DSS does not automatically install the tools and libraries required for running GPU workloads.
 It relies on Canonical K8s for the required operating-system drivers.

--- a/docs/how-to/dss.rst
+++ b/docs/how-to/dss.rst
@@ -8,10 +8,10 @@ This guide describes how to manage Data Science Stack (DSS).
 DSS is a Command Line Interface (CLI)-based environment and distributed as a `snap`_.
 
 Install
---------
+-------
 
 .. note::
-   To install DSS, ensure you have previously installed `Snap`_ and `MicroK8s`_.
+   To install DSS, ensure you have previously installed `Snap`_ and `Canonical K8s`_.
 
 You can install DSS using ``snap`` as follows:
 
@@ -26,20 +26,20 @@ Then, you can run the DSS CLI with:
     dss
 
 Initialise
------------
+----------
 
 You can initialise DSS through ``dss initialize``.
 This command:
 
-* Stores credentials for the MicroK8s cluster.
+* Stores credentials for the Canonical K8s cluster.
 * Allocates storage for your DSS Jupyter Notebooks.
 * Deploys an `MLflow <MLflow Docs_>`_ model registry.
 
 .. code-block:: shell
 
-    dss initialize --kubeconfig "$(sudo microk8s config)"
+    dss initialize --kubeconfig "$(sudo k8s config)"
 
-The ``--kubeconfig`` option is used to provide your MicroK8s cluster's kubeconfig.
+The ``--kubeconfig`` option is used to provide your Canonical K8s cluster's kubeconfig.
 
 .. note::
    Note the use of quotes for the ``--kubeconfig`` option. Without them, the content may be interpreted by your shell.
@@ -61,9 +61,9 @@ You should expect an output like this:
       dss create my-notebook --image=kubeflownotebookswg/jupyter-scipy:v1.8.0
 
 Remove
--------
+------
 
-You can remove DSS from your MicroK8s cluster through ``dss purge``. 
+You can remove DSS from your Canonical K8s cluster through ``dss purge``. 
 This command purges all the DSS components, including:
 
 * All Jupyter Notebooks.
@@ -72,7 +72,7 @@ This command purges all the DSS components, including:
 
 .. note::
 
-    This action removes the components of the DSS environment, but it does not remove the DSS CLI or your MicroK8s cluster.  
+    This action removes the components of the DSS environment, but it does not remove the DSS CLI or your Canonical K8s cluster.  
     To remove those, `delete their snaps <https://snapcraft.io/docs/quickstart-tour>`_.
 
 .. code-block:: bash
@@ -91,7 +91,7 @@ You should expect an output like this:
     Success: All DSS components and notebooks purged successfully from the Kubernetes cluster.
 
 Get status
------------
+----------
 
 You can check the DSS status through ``dss status``. 
 This command provides a quick way to check the status of your DSS environment, including the MLflow status and whether a GPU is detected in your environment.
@@ -109,7 +109,7 @@ If you already have a DSS environment running and no GPU available, the expected
     GPU acceleration: Disabled
 
 List commands
---------------
+-------------
 
 You can get the list of available commands for DSS through the ``dss`` command with the ``--help`` option:
 
@@ -134,12 +134,11 @@ You should expect an output like this:
     list        Lists all created notebooks in the DSS environment.
     logs        Prints the logs for the specified notebook or DSS component.
     purge       Removes all notebooks and DSS components.
-    remove      Remove a Jupter Notebook in DSS with the name NAME.
+    remove      Remove a Jupyter Notebook in DSS with the name NAME.
     start       Starts a stopped notebook in the DSS environment.
     status      Checks the status of key components within the DSS...
     stop        Stops a running notebook in the DSS environment.
 
-    
 **Get details about a specific command**:
 
 To see the usage and options of a DSS command, run ``dss <command>`` with the ``--help`` option.

--- a/docs/how-to/dss.rst
+++ b/docs/how-to/dss.rst
@@ -73,7 +73,7 @@ This command purges all the DSS components, including:
 .. note::
 
     This action removes the components of the DSS environment, but it does not remove the DSS CLI or your Canonical K8s cluster.  
-    To remove those, `delete their snaps <https://snapcraft.io/docs/quickstart-tour>`_.
+    To remove those, `delete their snaps <https://snapcraft.io/docs/get-started>`_.
 
 .. code-block:: bash
 

--- a/docs/how-to/enable-gpus/enable-intel-gpu.rst
+++ b/docs/how-to/enable-gpus/enable-intel-gpu.rst
@@ -5,26 +5,18 @@ Enable Intel GPUs
 
 This guide describes how to configure Data Science Stack (DSS) to utilise the Intel GPUs on your machine. 
 
-You can do so done by enabling the Intel device plugin on your `MicroK8s`_ cluster.
+You can do so by enabling the Intel device plugin on your `Canonical K8s`_ cluster.
 
 Prerequisites
 -------------
 
-* Ubuntu 22.04.
+* Ubuntu 24.04.
 * DSS is :ref:`installed <install_DSS_CLI>` and :ref:`initialised <initialise_DSS>`.
 * The `kubectl snap <https://snapcraft.io/kubectl>`_ package is installed.
 * Your machine includes an Intel GPU.
 
-.. note::
-   After installing `kubectl`, configure MicroK8s to run `kubectl` commands as follows:
-
-   .. code-block:: bash
-
-      mkdir -p ~/.kube
-      microk8s config > ~/.kube/config 
-
 Verify the Intel GPU drivers
-----------------------------------------------------------
+----------------------------
 
 To confirm that your machine has the Intel GPU drivers set up, first install the `intel-gpu-tools` package:
 
@@ -49,10 +41,10 @@ If the drivers are correctly installed, you should see information about your GP
 .. note::
    For Intel discrete GPUs on Ubuntu versions older than 24.04, you may need to perform additional steps such as installing a `HWE kernel <https://ubuntu.com/kernel/lifecycle>`_. 
 
-Enable the Intel GPU plugin 
-------------------------------------------------------
+Enable the Intel GPU plugin
+---------------------------
 
-To ensure DSS can utilise Intel GPUs, you have to enable the Intel GPU plugin in your MicroK8s cluster.
+To ensure DSS can utilise Intel GPUs, you have to enable the Intel GPU plugin in your Canonical K8s cluster.
 
 1. Use `kubectl kustomize` to build the plugin YAML configuration files:
 
@@ -69,7 +61,7 @@ To allow multiple containers to utilise the same GPU, run:
                 
   sed -i 's/enable-monitoring/enable-monitoring\n        - -shared-dev-num=10/' gpu_plugin.yaml
 
-2. Apply the built YAML files to your MicroK8s cluster:
+2. Apply the built YAML files to your Canonical K8s cluster:
 
 .. code-block:: bash
                 
@@ -77,14 +69,15 @@ To allow multiple containers to utilise the same GPU, run:
   kubectl apply -f node_feature_rules.yaml
   kubectl apply -f gpu_plugin.yaml
 
-The MicroK8s cluster is now configured to recognise and utilise your Intel GPU.
+The Canonical K8s cluster is now configured to recognise and utilise your Intel GPU.
 
 .. note::
  After the YAML configuration files have been applied, they can be safely deleted.
 
 Verify the Intel GPU plugin
--------------------------------------------------
-To verify the Intel GPU plugin is installed and the MicroK8s cluster recognises your GPU, run:
+---------------------------
+
+To verify the Intel GPU plugin is installed and the Canonical K8s cluster recognises your GPU, run:
 
 .. code-block:: bash
 
@@ -98,7 +91,7 @@ You should see an output with the cluster name such as the following:
    fluent-greenshank   Ready    <none>   18s   v1.30.3   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,intel.feature.node.kubernetes.io/gpu=true
 
 Verify DSS detects the GPU
-----------------------------------
+--------------------------
 
 Verify DSS has detected the GPU by checking the DSS status. To do so, run the following command using the DSS CLI: 
 

--- a/docs/how-to/enable-gpus/enable-nvidia-gpu.rst
+++ b/docs/how-to/enable-gpus/enable-nvidia-gpu.rst
@@ -13,19 +13,20 @@ Prerequisites
 * DSS is :ref:`installed <install_DSS_CLI>` and :ref:`initialised <initialise_DSS>`.
 * Your machine includes an NVIDIA GPU.
 
+.. _install_nvidia_operator:
+
 Install the NVIDIA GPU Operator
 -------------------------------
 
-To enable GPU support, you must install the NVIDIA GPU Operator in your Kubernetes cluster. Follow the official NVIDIA documentation for installation steps:
+To enable GPU support, you must install the NVIDIA GPU Operator in your Kubernetes cluster. 
+Follow `NVIDIA GPU Operator Installation Guide <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html>`_ for installation details.
 
-`NVIDIA GPU Operator Installation Guide <https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html>`_
-
-Verify the NVIDIA Operator is Up
+Verify the NVIDIA Operator is up
 --------------------------------
 
-Once the NVIDIA GPU Operator is installed, verify that it has successfully initialized before running workloads.
+Once the NVIDIA GPU Operator is installed, verify that it has been successfully initialized before running workloads.
 
-Ensure DaemonSet is Ready
+Ensure DaemonSet is ready
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Run the following command to verify that the DaemonSet for the NVIDIA Operator Validator is created:
@@ -46,7 +47,7 @@ Once completed, you should see an output similar to this:
    NAME                        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                                   AGE
    nvidia-operator-validator   1         1         0       1            0           nvidia.com/gpu.deploy.operator-validator=true   17s
 
-Ensure the Validator Pod Succeeded
+Ensure the Validator Pod succeeded
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Run the following command to check if the NVIDIA Operator validation is successful:
@@ -69,33 +70,35 @@ Once completed, the output should include:
 
    all validations are successful
 
-Use Cases for Different Driver States
+Use cases for different driver states
 -------------------------------------
 
 The NVIDIA GPU Operator behaves differently depending on whether your system already has an NVIDIA driver installed. Below are the three primary scenarios:
 
-Device with No NVIDIA Driver Installed
+Device with no NVIDIA driver installed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - The GPU Operator will **automatically install** the necessary NVIDIA driver.
 - This installation process may take longer as it involves setting up drivers and runtime components.
 - Once the process is complete, GPU should be detected successfully.
 
-Device with an Up-to-Date NVIDIA Driver
+Device with an up-to-date NVIDIA driver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - The GPU Operator detects the existing driver and proceeds without reinstalling it.
 - However, to avoid redundant installations, it is recommended to disable driver installation explicitly when deploying the operator.
 - Follow the upstream documentation for the correct configuration to disable driver installation in this case.
 
-Device with an Outdated NVIDIA Driver
+Device with an outdated NVIDIA driver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - If an older driver version is detected, the operator may attempt to install a newer version.
 - This could lead to conflicts if the outdated driver does not match the required CUDA version.
 - To prevent issues, update the driver manually or remove the outdated version before deploying the GPU Operator.
 
-Verify DSS Detects the GPU
+.. _verify_nvidia_operator:
+
+Verify DSS detects the GPU
 --------------------------
 
 After installing and configuring the NVIDIA GPU Operator, verify that DSS detects the GPU by checking its status:
@@ -104,7 +107,7 @@ After installing and configuring the NVIDIA GPU Operator, verify that DSS detect
 
    dss status
 
-Expected output:
+You should expect an output like this:
 
 .. code-block:: text
 

--- a/docs/how-to/enable-gpus/enable-nvidia-gpu.rst
+++ b/docs/how-to/enable-gpus/enable-nvidia-gpu.rst
@@ -60,7 +60,7 @@ Run the following command to check if the NVIDIA Operator validation is successf
    done
 
 .. note::
-   If the validator pod is still initializing, you may see an error like:
+   If the pod is still initializing, you may see an error like:
    ``Error from server (BadRequest): container "nvidia-operator-validator" in pod "nvidia-operator-validator-xxxx" is waiting to start: PodInitializing``
 
 Once completed, the output should include:
@@ -79,7 +79,7 @@ Device with No NVIDIA Driver Installed
 
 - The GPU Operator will **automatically install** the necessary NVIDIA driver.
 - This installation process may take longer as it involves setting up drivers and runtime components.
-- Once the process is complete, `nvidia-smi` should detect the GPU successfully.
+- Once the process is complete, GPU should be detected successfully.
 
 Device with an Up-to-Date NVIDIA Driver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/how-to/jupyter-notebook.rst
+++ b/docs/how-to/jupyter-notebook.rst
@@ -171,6 +171,8 @@ Stopping a notebook frees up resources and ensures data safety when not actively
 
     dss stop my-notebook
 
+.. _access_notebook:
+
 Access a notebook
 -----------------
 

--- a/docs/how-to/jupyter-notebook.rst
+++ b/docs/how-to/jupyter-notebook.rst
@@ -74,7 +74,6 @@ Select one of them and create a notebook as follows:
 
    dss create my-notebook --image=tensorflow-cuda
 
-
 You can confirm your GPU is detected and usable by running the following within your notebook:
 
 .. code-block:: python
@@ -112,13 +111,6 @@ Select one of them and create a notebook as follows:
 
    dss create my-itex-notebook --image=tensorflow-intel
 
-.. note::
-
-   Once created, you can :ref:`access it <access_notebook>` and run Intel-based ML workloads within your DSS environment. 
-   See `IPEX example <https://intel.github.io/intel-extension-for-pytorch/xpu/latest/tutorials/examples.html#float32>`_ 
-   and `ITEX example <https://github.com/intel/intel-extension-for-tensorflow/blob/main/examples/quick_example.md>`_ 
-   for detailed examples using the Intel extensions for Pytorch and Tensorflow respectively. 
-
 You can confirm your Intel GPU is detected and usable by running the following within your notebook:
 
 .. code-block:: python
@@ -126,16 +118,6 @@ You can confirm your Intel GPU is detected and usable by running the following w
    import tensorflow as tf
 
    tf.config.experimental.list_physical_devices()
-
-For example, you should expect an output like the following for a host system containing an Intel CPU and a single Intel GPU:
-
-.. code-block:: python
-
-    [PhysicalDevice(name='/physical_device:CPU:0', device_type='CPU'), PhysicalDevice(name='/physical_device:XPU:0', device_type='XPU')]
-
-.. note::
-
-    Intel denotes XPU the combination of an Intel CPU with GPU.
 
 List created notebooks
 ----------------------
@@ -147,45 +129,13 @@ To view the full list, run:
 
     dss list
 
-This command displays each notebook name along with its associated image, state and URL if applicable. 
-For example:
-
-.. code-block:: none
-
-    Name          Image                                               URL                      
-    my-notebook   kubeflownotebookswg/jupyter-tensorflow-full:v1.8.0  http://10.152.183.164:80  (Active)
-    data-prep     kubeflownotebookswg/jupyter-minimal:v1.5.0          (Downloading)
-    test-env      kubeflownotebookswg/jupyter-scipy-notebook:v1.9.0   (Stopping)
-
-.. _notebook_states:
-
-Notebook states
-~~~~~~~~~~~~~~~
-
-Each notebook can be in one of the following states:
-
-* **Active**: The notebook is running and accessible. You can use the URL under the *URL* column to access it.
-
-* **Stopped**: The notebook is not running. 
-
-* **Stopping**: The notebook is in the process of stopping. It is advisable to wait until the process completes, transitioning to *Stopped*.
-
-* **Starting**: The notebook is initialising and will soon be *Active*.
-
-* **Downloading**: The notebook is downloading the specified OCI Image. This is a transient state before it becomes *Active*.
-
-* **Removing**: The notebook is in the process of being removed. This is a transient state before it is fully removed.
+This command displays each notebook name along with its associated image, state, and URL if applicable. 
 
 Remove a notebook
 -----------------
 
 You can remove a Jupyter Notebook using the DSS CLI.
 It is a non-blocking process, meaning you can continue other work while the deletion completes.
-
-.. note::
-
-   When you remove a notebook, any data stored under `~/shared` within the notebook will be preserved and remain accessible to other notebooks. 
-   This shared storage is designed to ensure that valuable data is not lost even when individual notebooks are removed from the environment.
 
 1. **Remove the notebook**:
 
@@ -201,57 +151,15 @@ You should expect an output like this:
 
     Removing the notebook my-notebook. Check `dss list` for the status of the notebook.
 
-2. **Verify the notebook has been removed**:
-
-To confirm the notebook has been removed, you can check the list of notebooks again: 
-
-.. code-block:: bash
-
-    dss list
-
-If the notebook has been successfully removed, it will no longer appear in the list. 
-If it's still showing as *Removing*, you may need to wait a bit longer or investigate if there are any issues preventing its deletion.
-
-.. _start_notebook:
-
 Start a notebook
 ----------------
 
 You can start a notebook using the DSS CLI.
 This enables you to resume your work without needing to configure a new notebook.
 
-1. **Start the notebook**:
-
-To start the notebook, use the ``dss start`` command followed by the name of the notebook, ``my-notebook`` in this example:
-
 .. code-block:: bash
 
     dss start my-notebook
-
-You should expect an output like this:
-
-.. code-block:: none
-
-    Executing start command
-    Starting the notebook my-notebook. Check `dss list` for the status of the notebook.
-
-2. **Verify the notebook is running**:
-
-After starting it, the notebook may go through :ref:`different states <notebook_states>`. 
-To check its state, run:
-
-.. code-block:: bash
-
-    dss list
-
-Once ready, you should expect an output like this:
-
-.. code-block:: none
-
-    Name          Image                                               URL                      
-    my-notebook   kubeflownotebookswg/jupyter-tensorflow-full:v1.8.0  http://10.152.183.164:80
-
-You can use this URL to :ref:`access the notebook <access_notebook>`.
 
 Stop a notebook
 ---------------
@@ -259,37 +167,9 @@ Stop a notebook
 You can stop a notebook using the DSS CLI.
 Stopping a notebook frees up resources and ensures data safety when not actively working on it. 
 
-1. **Stop the notebook**:
-
-To stop a running notebook, use the ``dss stop`` command followed by the name of the notebook, ``my-notebook`` in this example:
-
 .. code-block:: bash
 
     dss stop my-notebook
-
-You should see an output like this:
-
-.. code-block:: none
-
-    Stopping the notebook my-notebook. Check `dss list` for the status of the notebook.
-
-2. **Verify the notebook has stopped**:
-
-After stopping it, the notebook may go through :ref:`different states <notebook_states>`. 
-To confirm it has stopped, check its state:
-
-.. code-block:: bash
-
-    dss list
-
-You should expect an output like this: 
-
-.. code-block:: none
-
-    Name          Image                                               URL       
-    my-notebook   kubeflownotebookswg/jupyter-tensorflow-full:v1.8.0  (Stopped)
-
-.. _access_notebook:
 
 Access a notebook
 -----------------
@@ -297,11 +177,6 @@ Access a notebook
 You can access a notebook User Interface (UI) using the DSS CLI.
 Accessing the UI enables you to interact directly with your notebook, run code, and visualise data. 
 This is done through a web browser by navigating to the URL associated with your active notebook.
-
-.. note::
-
-    Ensure your notebook is in *Active* :ref:`state <notebook_states>` to be able to access it.
-    Otherwise, you may need to :ref:`start <start_notebook>` it or check for any issues that are preventing it from being accessible.
 
 1. **Find the notebook URL**:
 
@@ -312,19 +187,10 @@ To find the URL of your notebook, first list all the notebooks:
     dss list
 
 Look for your notebook in the output, and specifically check the URL column. 
-An active notebook has associated a URL, which indicates it is ready for accessing.
-
-You should expect an output like this:
-
-.. code-block:: none
-
-    Name          Image                                               URL                      
-    my-notebook   kubeflownotebookswg/jupyter-tensorflow-full:v1.8.0  http://10.152.183.164:80
 
 2. **Access the Notebook UI**:
 
 Once you know the URL, open a web browser and enter the URL into the address bar. 
-This will direct you to the notebook UI where you can start working with your notebook.   
 
 Get notebook logs
 -----------------
@@ -332,137 +198,9 @@ Get notebook logs
 You can retrieve logs for a Jupyter Notebook using the DSS CLI.
 Retrieving logs can help you troubleshoot issues, monitor notebook activities, or verify actions taken in the notebook. 
 
-To get the logs for a certain notebook, use the ``dss logs`` command followed by the name of the notebook, ``my-notebook`` in this example:
-
 .. code-block:: bash
     
     dss logs my-notebook
-
-You should expect an output like this:
-
-.. code-block:: none
-
-    Logs for my-notebook-8cf4d9bc-jm9zm:
-    s6-rc: info: service s6rc-oneshot-runner: starting
-    s6-rc: info: service s6rc-oneshot-runner successfully started
-    s6-rc: info: service fix-attrs: starting
-    s6-rc: info: service fix-attrs successfully started
-    s6-rc: info: service legacy-cont-init: starting
-    cont-init: info: running /etc/cont-init.d/01-copy-tmp-home
-    cont-init: info: /etc/cont-init.d/01-copy-tmp-home exited 0
-    s6-rc: info: service legacy-cont-init successfully started
-    s6-rc: info: service legacy-services: starting
-    services-up: info: copying legacy longrun jupyterlab (no readiness notification)
-    s6-rc: info: service legacy-services successfully started
-    [W 2024-04-30 13:44:20.991 ServerApp] ServerApp.token config is deprecated in 2.0. Use IdentityProvider.token.
-    [I 2024-04-30 13:44:20.996 ServerApp] Package jupyterlab took 0.0000s to import
-    [I 2024-04-30 13:44:20.997 ServerApp] Package jupyter_server_fileid took 0.0013s to import
-    [I 2024-04-30 13:44:20.998 ServerApp] Package jupyter_server_mathjax took 0.0007s to import
-    [I 2024-04-30 13:44:21.001 ServerApp] Package jupyter_server_terminals took 0.0024s to import
-    [I 2024-04-30 13:44:21.012 ServerApp] Package jupyter_server_ydoc took 0.0105s to import
-    [I 2024-04-30 13:44:21.022 ServerApp] Package jupyterlab_git took 0.0104s to import
-    [I 2024-04-30 13:44:21.022 ServerApp] Package nbclassic took 0.0000s to import
-
-.. _notebook-mlflow:
-
-Connect from notebook to MLflow
--------------------------------
-
-You can integrate `MLflow <Charmed MLflow_>`_ with your Jupyter Notebook for tracking experiments using DSS. 
-
-MLflow is a platform for managing the end-to-end machine learning life cycle. 
-It includes tracking experiments, packaging code into reproducible runs, and sharing and deploying models. 
-
-DSS environments are pre-configured to interact with an MLflow server through the `MLFLOW_TRACKING_URI` environment variable set in each notebook.
-
-Installing MLflow
-~~~~~~~~~~~~~~~~~
-
-To interact with MLflow, the MLflow Python library needs to be installed within your notebook environment. 
-There are two ways to install the MLflow library:
-
-1. **Within a notebook cell** (Recommended):
-
-It's recommended to install MLflow directly within a notebook cell to ensure the library is available for all subsequent cells during your session:
-
-.. code-block:: none
-
-    %%bash
-    pip install mlflow
-
-2. **Using the notebook terminal**:
-
-Alternatively, you can install MLflow from the notebook terminal with the same command. 
-This method also installs MLflow for the current session:
-
-.. code-block:: bash
-
-    pip install mlflow
-
-Note that any installations via the notebook or terminal will not persist after the notebook is restarted.
-Therefore, the first method is preferred to ensure consistency across sessions.
-
-Connecting to MLflow library
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-After installing MLflow, you can directly interact with the MLflow server configured for your DSS environment:
-
-.. code-block:: python
-
-    import mlflow
-
-    c = mlflow.MlflowClient()
-
-    print(c.tracking_uri)  
-
-    c.create_experiment("test-experiment")
-
-This example shows how to initialise the MLflow client, check the tracking URI, and create a new experiment. 
-The `MLFLOW_TRACKING_URI` should already be set in your environment, allowing you to focus on your experiments without manual configuration.
-
-For more detailed information on using MLflow, including advanced configurations and features, refer to the official `MLflow Docs`_.
-
-.. _access-data:
-
-Access your data from DSS
--------------------------
-
-You can access the stored data from your notebooks using the DSS CLI.
-Accessing your data is useful when you want to browse or modify the files stored from your notebooks.
-
-.. note::
-    By default, your notebooks data are stored in a directory under `/var/snap/microk8s/common/default-storage`. 
-    See `Microk8s hostpath docs`_ for more information.
-
-This directory is shared by all your DSS notebooks.
-
-1. **Find the directory of your stored data**
-    
-To find the directory containing your notebooks data, list the directories under `/var/snap/microk8s/common/default-storage`:
-
-.. code-block:: bash
-
-    ls /var/snap/microk8s/common/default-storage/
-
-
-You should see an output like this:
-
-.. code-block:: bash
-
-    dss-notebooks-pvc-00037e23-e2e2-4ab4-9088-45099154da30
-
-The storage directory is the one prefixed with `dss-notebooks-pvc` as shown in the output.
-
-.. note::
-
-    The characters that follow `dss-notebooks-pvc-` may not be the same for all DSS environments.
-
-2. **Access your notebooks data**
-
-From your local file browser, navigate to the folder `/var/snap/microk8s/common/default-storage/[directory name]`. 
-Use the directory name you got from the previous step.
-
-Now, you can view and manage all your stored notebooks data.
 
 See also
 --------

--- a/docs/how-to/mlflow.rst
+++ b/docs/how-to/mlflow.rst
@@ -71,7 +71,7 @@ You should expect an output like this:
 Get artefacts
 --------------
 
-MLflow artefacts, including `models <https://mlflow.org/docs/latest/models.html>`_, `experiments <https://mlflow.org/docs/latest/tracking.html#experiments>`_ and `runs <https://mlflow.org/docs/latest/tracking.html#runs>`_ are stored within your DSS environment.
+MLflow artefacts, including `models <https://mlflow.org/docs/latest/models.html>`_, `experiments <https://mlflow.org/docs/latest/tracking/>`_ and `runs <https://mlflow.org/docs/latest/tracking.html#runs>`_ are stored within your DSS environment.
 You can access and download them from the :ref:`MLflow UI <access_mlflow>`. 
 
 See also

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,15 +5,15 @@ Data Science Stack documentation
 ================================
 
 Data Science Stack (DSS) is a ready-to-run environment for Machine Learning (ML) and data science.  
-It's built on open-source tooling, including MicroK8s, JupyterLab and MLflow, and usable on any Ubuntu/Snap-enabled workstation.
+It's built on open-source tooling, including Canonical K8s, JupyterLab, and MLflow, and is usable on any Ubuntu/Snap-enabled workstation.
 
-DSS provides a Command Line Interface (CLI) for managing containerised ML environments images such as PyTorch or TensorFlow, on top of MicroK8s.
+DSS provides a Command Line Interface (CLI) for managing containerised ML environment images such as PyTorch or TensorFlow, on top of Canonical K8s.
 
-Typically, creating ML environments on a workstation involves complex and hard-to-reverse configuration. 
-DSS solves this problem by making accessible, production-ready, isolated and reproducible ML environments, that make full use of a workstation's GPUs.
+Typically, creating ML environments on a workstation involves complex and hard-to-reverse configurations. 
+DSS solves this problem by providing accessible, production-ready, isolated, and reproducible ML environments that fully utilise a workstation's GPUs.
 
 Both ML beginners and engineers who need to build complex development and runtime environments will see set-up time reduced to a minimum, 
-allowing them to get on with useful work within minutes.
+allowing them to get started with meaningful work within minutes.
 
 ---------
 

--- a/docs/reuse/links.txt
+++ b/docs/reuse/links.txt
@@ -3,6 +3,7 @@
 .. _How to publish documentation on Read the Docs: https://library.canonical.com/documentation/publish-on-read-the-docs
 .. _Example product documentation: https://canonical-example-product-documentation.readthedocs-hosted.com/
 
+.. _Canonical K8s: https://snapcraft.io/k8s
 .. _Charmed MLflow: https://documentation.ubuntu.com/charmed-mlflow/en/latest/
 .. _Code of conduct: https://ubuntu.com/community/ethos/code-of-conduct
 .. _Contribute: https://github.com/canonical/data-science-stack/blob/main/CONTRIBUTING.md
@@ -14,6 +15,7 @@
 .. _MicroK8s requirements: https://microk8s.io/docs/getting-started
 .. _MLflow Docs: https://mlflow.org/docs/latest/index.html
 .. _NVIDIA Operator: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html
+.. _NVIDIA GPU Operator: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html
 .. _Pod: https://kubernetes.io/docs/concepts/workloads/pods/
 .. _Snap: https://snapcraft.io/
 

--- a/docs/tutorial/get-started.rst
+++ b/docs/tutorial/get-started.rst
@@ -97,6 +97,5 @@ This will direct you to the notebook UI where you can start working with your no
 Next Steps
 ----------
 * To learn more about how to interact with DSS, see :ref:`manage_DSS`.
-* To learn about handling data, check out :ref:`access-data`.
 * To connect to MLflow, see :ref:`manage_MLflow`.
 * To leverage your GPUs, see :doc:`Enable GPUs <../how-to/enable-gpus/index>`.

--- a/docs/tutorial/get-started.rst
+++ b/docs/tutorial/get-started.rst
@@ -4,35 +4,34 @@ Get started with DSS
 ====================
 
 This guide describes how you can get started with Data Science Stack (DSS). 
-From setting up MicroK8s in your host environment, all the way to running your first notebook.
+From setting up Canonical K8s in your host environment, all the way to running your first notebook.
 
 Data Science Stack is a ready-made environment that makes it seamless to run GPU-enabled containerised Machine Learning (ML) environments. 
 It provides easy access to a solution for developing and optimising ML models, utilising your machine's GPUs and allowing users to utilise different ML environment images based on their needs.
 
-Prerequisites
+Requirements
 -------------
 
-* Ubuntu 22.04 LTS.
+* Ubuntu 24.04 LTS.
 * `Snap`_ installed.
-* 50GB of disk space is recommended. This includes the `requirements <https://microk8s.io/docs/getting-started>`_ for MicroK8s.
+* 50GB of disk space is recommended.
 
-.. _set_microk8s:
+.. _set_canonical_k8s:
 
-Set up MicroK8s
----------------
+Set up Canonical K8s
+--------------------
 
 DSS relies on a container orchestration system, capable of exposing the host GPUs to the workloads. 
-`MicroK8s`_ is used as the orchestration system.
-All the workloads and state managed by DSS are running on top of MicroK8s.
+`Canonical K8s`_ is used as the orchestration system.
+All the workloads and state managed by DSS are running on top of Canonical K8s.
 
-You can install MicroK8s using ``snap`` as follows:
+You can install Canonical K8s using ``snap`` as follows:
 
 .. code-block:: bash
 
-   sudo snap install microk8s --channel 1.28/stable --classic
-   sudo microk8s enable hostpath-storage
-   sudo microk8s enable dns
-   sudo microk8s enable rbac
+   sudo snap install k8s --classic --channel=1.32-classic/stable
+   sudo k8s bootstrap
+   sudo k8s enable local-storage
 
 .. _install_DSS_CLI:
 
@@ -44,18 +43,18 @@ Now, install the DSS CLI using the following command:
 
 .. code-block:: bash
 
-   sudo snap install data-science-stack --channel latest/stable
+   sudo snap install data-science-stack
 
 .. _initialise_DSS:
 
 Initialise DSS
 --------------
 
-Next, you need to initialise DSS on top of MicroK8s and prepare MLflow:
+Next, you need to initialise DSS on top of Canonical K8s and prepare MLflow:
 
 .. code-block:: bash
 
-   dss initialize --kubeconfig="$(sudo microk8s config)"
+   dss initialize --kubeconfig="$(sudo k8s config)"
 
 .. note::
 


### PR DESCRIPTION
This PR addresses and **closes [#200](https://github.com/canonical/data-science-stack/issues/200)** by replacing all references to **MicroK8s** with **Canonical K8s** across the documentation. Additionally, the sections related to accessing host path storage data have been removed where applicable.

## Changes made:
- Updated installation, initialization, and management steps to reflect Canonical K8s (`manage_DSS.rst`, `tutorial.rst`).
- Adjusted GPU-related setup instructions for NVIDIA and Intel to align with Canonical K8s (`enable_gpu.rst`, `enable_intel_gpu.rst`).
- Revised the DSS architecture overview to reflect the new orchestration system (`dss_architecture.rst`).
- Removed host path storage access sections (`manage_notebooks.rst`).
- Updated the home and general structure files to ensure consistency (`home.rst`).