### PR TITLE
fix: 404 page rendering

### DIFF
--- a/docs/custom_conf.py
+++ b/docs/custom_conf.py
@@ -108,7 +108,7 @@ html_context = {
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.
-slug = ""
+slug = "data-science-stack"
 
 ############################################################
 # Redirects


### PR DESCRIPTION
As these docs are on documentation.ubuntu.com 404 pages do not render properly without the slug defined in conf.py