### PR TITLE
backport: Bump timeout to 600 seconds, 180 often caused timeout errors (#220)

### DIFF
--- a/src/dss/utils.py
+++ b/src/dss/utils.py
@@ -44,7 +44,7 @@ def wait_for_deployment_ready(
     client: Client,
     namespace: str,
     deployment_name: str,
-    timeout_seconds: Optional[int] = 180,
+    timeout_seconds: Optional[int] = 600,
     interval_seconds: int = 10,
 ) -> None:
     """


### PR DESCRIPTION
Backports: https://github.com/canonical/data-science-stack/pull/220